### PR TITLE
Address signature reuse vulnerability

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1503,6 +1503,19 @@ validation of domain names.  If ACME is extended in the future to support other
 types of identifier, there will need to be new Challenge types, and they will
 need to specify which types of identifier they apply to.
 
+[[ Editor's Note: In pre-RFC versions of this specification, challenges are
+labeled by type, and with the version of the draft in which they were
+introduced.  For example, if an HTTP challenge were introduced in version -03
+and a breaking change made in version -05, then there would be a challenge
+labeled "http-03" and one labeled "http-05" -- but not one labeled "http-04",
+since challenge in version -04 was compatible with one in version -04. ]]
+
+[[ Editor's Note: Operators SHOULD NOT issue "combinations" arrays in
+authorization objects that require the client to perform multiple challenges
+over the same type, e.g., ["http-03", "http-05"].  Challenges within a type are
+testing the same capability of the domain owner, and it may not be possible to
+satisfy both at once. ]]
+
 ## Authorized Key Objects
 
 Several of the challenges in this document makes use of an "authorized key"
@@ -1550,11 +1563,13 @@ object MUST match the client's account key.
 }
 ~~~~~~~~~~
 
-A client responds to this challenge by parsing the authorized key object,
-verifying that its "key" field contains the client's account key, and
-provisioning it as a resource on the HTTP server for the domain in question.
-(Note: The provisioned object need not be a byte-exact copy of the authorized
-keys object in the challenge, but it MUST represent the same JSON object.)
+A client responds to this challenge by base64-decoding and parsing the
+authorized key object, verifying that its "key" field contains the client's
+account key, and provisioning it as a resource on the HTTP server for the domain
+in question.  That is, the server provisions a JSON object that is equivalent to
+the object encoded in the "authorizedKey" field sent by the server. (Note: The
+provisioned object need not be a byte-exact copy of the authorized keys object
+in the challenge.)
 
 ~~~~~~~~~~
 {
@@ -1598,7 +1613,7 @@ domain by verifying that the resource was provisioned as expected.
 1. Verify that the "token" value in the response matches the "token" field in
    the authorized key object in the challenge.
 2. Form a URI by populating the URI template {{RFC6570}}
-"{scheme}://{domain}/.well-known/acme-challenge/{token}", where:
+   "{scheme}://{domain}/.well-known/acme-challenge/{token}", where:
   * the scheme field is set to "http" if the "tls" field in the response is
     present and set to false, and "https" otherwise;
   * the domain field is set to the domain name being verified; and
@@ -1607,7 +1622,7 @@ domain by verifying that the resource was provisioned as expected.
 4. Dereference the URI using an HTTP or HTTPS GET request.  If using HTTPS, the
    ACME server MUST ignore the certificate provided by the HTTPS server.
 5. Verify that the Content-Type header of the response is either absent, or has
-the value "application/json".
+   the value "application/json".
 6. Verify that the body of the response is well-formed authorized key object.
 7. Verify that the "key" and "token" fields in the authorized key object match
    the values from the authorized key object in the challenge.

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1193,6 +1193,12 @@ ignore any fields in the response object that are not specified as response
 fields for this type of challenge.  The server provides a 200 (OK) response
 with the updated challenge object as its body.
 
+If the client's response is invalid for some reason, or does not provide the
+server with appropriate information to validate the challenge, then the server
+MUST return an HTTP error.  On receiving such an error, the client MUST undo any
+actions that have been taken to fulfil the challenge, e.g., removing files that
+have been provisioned to a web server.
+
 Presumably, the client's responses provide the server with enough information to
 validate one or more challenges.  The server is said to "finalize" the
 authorization when it has completed all the validations it is going to complete,
@@ -1607,24 +1613,27 @@ Otherwise the check will be done over HTTPS, on port 443.
 /* Signed as JWS */
 ~~~~~~~~~~
 
+On receiving a response, the server MUST verify that the "token" value in the
+response matches the "token" field in the authorized key object in the
+challenge.  If they do not match, then the server MUST return an HTTP error in
+response to the POST request in which the client sent the challenge
+
 Given a Challenge/Response pair, the server verifies the client's control of the
 domain by verifying that the resource was provisioned as expected.
 
-1. Verify that the "token" value in the response matches the "token" field in
-   the authorized key object in the challenge.
-2. Form a URI by populating the URI template {{RFC6570}}
+1. Form a URI by populating the URI template {{RFC6570}}
    "{scheme}://{domain}/.well-known/acme-challenge/{token}", where:
   * the scheme field is set to "http" if the "tls" field in the response is
     present and set to false, and "https" otherwise;
   * the domain field is set to the domain name being verified; and
   * the token field is set to the token in the authorized key object.
-3. Verify that the resulting URI is well-formed.
-4. Dereference the URI using an HTTP or HTTPS GET request.  If using HTTPS, the
+2. Verify that the resulting URI is well-formed.
+3. Dereference the URI using an HTTP or HTTPS GET request.  If using HTTPS, the
    ACME server MUST ignore the certificate provided by the HTTPS server.
-5. Verify that the Content-Type header of the response is either absent, or has
+4. Verify that the Content-Type header of the response is either absent, or has
    the value "application/json".
-6. Verify that the body of the response is well-formed authorized key object.
-7. Verify that the "key" and "token" fields in the authorized key object match
+5. Verify that the body of the response is well-formed authorized key object.
+6. Verify that the "key" and "token" fields in the authorized key object match
    the values from the authorized key object in the challenge.
 
 Comparisons of the "token" field MUST be performed in terms of
@@ -1686,17 +1695,20 @@ token (required, string):
 }
 ~~~~~~~~~~
 
+On receiving a response, the server MUST verify that the "token" value in the
+response matches the "token" field in the authorized key object in the
+challenge.  If they do not match, then the server MUST return an HTTP error in
+response to the POST request in which the client sent the challenge
+
 Given a Challenge/Response pair, the ACME server verifies the client's control
 of the domain by verifying that the TLS server was configured appropriately.
 
-1. Verify that the "token" value in the response matches the "token" field in
-   the authorized key object in the challenge.
-2. Compute the Z-value from the authorized key object in the same way as the
+1. Compute the Z-value from the authorized key object in the same way as the
    client.
-3. Open a TLS connection to the domain name being validated on port 443,
+2. Open a TLS connection to the domain name being validated on port 443,
    presenting the value "\<Z[0:32]\>.\<Z[32:64]\>.acme.invalid" in the SNI
    field (where the comparison is case-insensitive).
-4. Verify that the certificate contains a subjectAltName extension with the
+3. Verify that the certificate contains a subjectAltName extension with the
    dNSName of "\<Z[0:32]\>.\<Z[32:64]\>.acme.invalid".
 
 It is RECOMMENDED that the ACME server validation TLS connections from multiple
@@ -1874,13 +1886,16 @@ token (required, string):
 }
 ~~~~~~~~~~
 
+On receiving a response, the server MUST verify that the "token" value in the
+response matches the "token" field in the authorized key object in the
+challenge.  If they do not match, then the server MUST return an HTTP error in
+response to the POST request in which the client sent the challenge
+
 To validate a DNS challenge, the server performs the following steps:
 
-1. Verify that the "token" value in the response matches the "token" field in
-   the authorized key object in the challenge.
-2. Compute the SHA-256 digest of the authorized key object
-3. Query for TXT records under the validation domain name
-4. Verify that the contents of one of the TXT records matches the digest value
+1. Compute the SHA-256 digest of the authorized key object
+2. Query for TXT records under the validation domain name
+3. Verify that the contents of one of the TXT records matches the digest value
 
 If all of the above verifications succeed, then the validation is successful.
 If no DNS record is found, or DNS record and response payload do not pass these

--- a/draft-ietf-acme.md
+++ b/draft-ietf-acme.md
@@ -482,7 +482,7 @@ label) MUST NOT be included in authorization requests.  See
       "type": "simpleHttp",
       "status": "valid",
       "validated": "2014-12-01T12:05Z",
-      "token": "IlirfxKKXAsHtmzK29Pj8A"
+      "authorizedKey": "SXQe-2XODaDxNRsbp0h...fMsNxvb29HhjjLPSggwiE"
     }
   ],
 }
@@ -1179,7 +1179,7 @@ Host: example.com
 {
   "resource": "challenge",
   "type": "simpleHttp",
-  "tls": false
+  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA" 
 }
 /* Signed as JWS */
 ~~~~~~~~~~
@@ -1232,7 +1232,7 @@ HTTP/1.1 200 OK
       "type": "simpleHttp"
       "status": "valid",
       "validated": "2014-12-01T12:05Z",
-      "token": "IlirfxKKXAsHtmzK29Pj8A"
+      "authorizedKey": "SXQe-2XODaDxNRsbp0h...fMsNxvb29HhjjLPSggwiE"
     }
   ]
 }


### PR DESCRIPTION
@agwa pointed out on the IETF ACME list that the current ACME challenges are vulnerable to a signature reuse attack, with an artfully chosen account key pair. This PR addresses that vulnerability by replacing the signature with a digest and reducing the client's control over the contents of the validation object.

This PR is ported from letsencrypt/acme-spec#223 (and based on top of #5).  It also includes some additional changes to address comments in that PR.