### PR TITLE
Clarify encoding for certs in PoP challenge

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1753,7 +1753,7 @@ type (required, string):
 : The string "proofOfPossession-01"
 
 certs (optional, array of string):
-: An array of certificates, in Base64-encoded DER format, that contain
+: An array of certificates, in Base64url-encoded DER format, that contain
 acceptable public keys.
 
 


### PR DESCRIPTION
They should be base64url rather than base64, for symmetry with rest of spec.