### PR TITLE
Simplify TLS SNI challenge

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1645,35 +1645,26 @@ token (required, string):
 at least 128 bits of entropy, in order to prevent an attacker from guessing it.
 It MUST NOT contain any characters outside the URL-safe Base64 alphabet.
 
-n (required, number):
-: Number of tls-sni-01 iterations
-
 ~~~~~~~~~~
 {
   "type": "tls-sni-01",
-  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA",
-  "n": 25
+  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA"
 }
 ~~~~~~~~~~
 
 A client responds to this challenge by constructing a key authorization from
 the "token" value provided in the challenge and the client's account key.  The
-client first computes the SHA-256 digest Z0 of the UTF8-encoded key
-authorization, and encodes Z0 in UTF-8 lower-case hexadecimal form. The client
-then generates iterated hash values Z1...Z(n-1) as follows:
+client computes the SHA-256 digest Z of the UTF8-encoded key
+authorization, and encodes Z in UTF-8 lower-case hexadecimal form.
 
-~~~~~~~~~~
-Z(i) = lowercase_hexadecimal(SHA256(Z(i-1))).
-~~~~~~~~~~
-
-The client generates a self-signed certificate for each iteration of Zi with a
+The client generates a self-signed certificate for with a
 single subjectAlternativeName extension dNSName that is
-"\<Zi[0:32]\>.\<Zi[32:64]\>.acme.invalid", where "Zi[0:32]" and "Zi[32:64]"
+"\<Z[0:32]\>.\<Z[32:64]\>.acme.invalid", where "Z[0:32]" and "Z[32:64]"
 represent the first 32 and last 32 characters of the hex-encoded value,
 respectively (following the notation used in Python).  The client then
 configures the TLS server at the domain such that when a handshake is initiated
 with the Server Name Indication extension set to
-"\<Zi[0:32]\>.\<Zi[32:64]\>.acme.invalid", the corresponding generated
+"\<Z[0:32]\>.\<Z[32:64]\>.acme.invalid", the corresponding generated
 certificate is presented.
 
 The response to the TLS SNI challenge simply acknowledges that the client is ready
@@ -1696,26 +1687,17 @@ key.  If they do not match, then the server MUST return an HTTP error in
 response to the POST request in which the client sent the challenge.
 
 Given a Challenge/Response pair, the ACME server verifies the client's control
-of the domain by verifying that the TLS server was configured appropriately.
+of the domain by verifying that the TLS server was configured appropriately,
+using these steps:
 
-1. Choose a subset of the N iterations to check, according to local policy.
-2. For each iteration, compute the Zi-value from the key authorization in
-   the same way as the client.
-3. Open a TLS connection to the domain name being validated on the requested
-   port, presenting the value "\<Zi[0:32]\>.\<Zi[32:64]\>.acme.invalid" in the
+1. Compute the Z-value from the key authorization in the same way as the client.
+2. Open a TLS connection to the domain name being validated on the requested
+   port, presenting the value "\<Z[0:32]\>.\<Z[32:64]\>.acme.invalid" in the
    SNI field (where the comparison is case-insensitive).
-4. Verify that the certificate contains a subjectAltName extension with the
+3. Verify that the certificate contains a subjectAltName extension with the
    dNSName of "\<Z[0:32]\>.\<Z[32:64]\>.acme.invalid", and that no other dNSName
    entries of the form "*.acme.invalid" are present in the subjectAltName
    extension.
-
-It is RECOMMENDED that the ACME server verify a random subset of the N
-iterations with an appropriate sized to ensure that an attacker who can
-provision certs for a default virtual host, but not for arbitrary simultaneous
-virtual hosts, cannot pass the challenge.  For instance, testing a subset of 5
-of N=25 domains ensures that such an attacker has only a one in 25/5 chance of
-success if they post certs Zn in random succession.  (This probability is
-enforced by the requirement that each certificate have only one Zi value.)
 
 It is RECOMMENDED that the ACME server validation TLS connections from multiple
 vantage points to reduce the risk of DNS hijacking attacks.


### PR DESCRIPTION
Simplify the TLS SNI challenge by removing the iterations concept, which I believe is not necessary in practice and complicates the protocol needlessly.