### PR TITLE
Add `rateLimited` error and clarify use of error URNs

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -517,7 +517,7 @@ When the server responds with an error status, it SHOULD provide additional
 information using problem document {{I-D.ietf-appsawg-http-problem}}.  The
 "type" and "detail" fields MUST be populated.  To facilitate automatic response
 to errors, this document defines the following standard tokens for use in the
-"type" field (within the "urn:acme:" namespace):
+"type" field (within the "urn:ietf:params:acme:error:" namespace):
 
 | Code            | Semantic                                                 |
 |:----------------|:---------------------------------------------------------|
@@ -532,9 +532,9 @@ to errors, this document defines the following standard tokens for use in the
 | unknownHost     | The server could not resolve a domain name               |
 | rateLimited     | The request exceeds a rate limit                         |
 
-This list is not exhaustive. The server MAY return errors whose "type"
-field is not on this list. Clients SHOULD display the "detail" field of such
-errors.
+This list is not exhaustive. The server MAY return errors whose "type" field is
+set to a URI other than those defined above. Clients SHOULD display the "detail"
+field of such errors.
 
 Authorization and challenge objects can also contain error information to
 indicate why the server was unable to validate authorization.

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -533,8 +533,9 @@ to errors, this document defines the following standard tokens for use in the
 | rateLimited     | The request exceeds a rate limit                         |
 
 This list is not exhaustive. The server MAY return errors whose "type" field is
-set to a URI other than those defined above. Clients SHOULD display the "detail"
-field of such errors.
+set to a URI other than those defined above.  Servers MUST NOT use the ACME URN
+namespace for errors other than the standard types.  Clients SHOULD display the
+"detail" field of such errors.
 
 Authorization and challenge objects can also contain error information to
 indicate why the server was unable to validate authorization.


### PR DESCRIPTION
In addition to adding the `rateLimited` error, as proposed in #17, this PR fixes some issues discussed in the F2F meeting, namely moving ACME URNs under the IETF parameters space, and having errors be a sub-namespace of an overall ACME namespace.