### PR TITLE
suggest using DNS over TCP when verifying challenges

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2073,6 +2073,10 @@ perform all necessary checks before issuing.
 
 There are certain factors that arise in operational reality that operators of
 ACME-based CAs will need to keep in mind when configuring their services.
+For example:
+
+* It is advisable to perform DNS queries via TCP to mitigate DNS forgery
+  attacks over UDP
 
 [[ TODO: Other operational considerations ]]
 


### PR DESCRIPTION
I've noticed that boulder uses DNS over TCP. I suppose this has not been an arbitrary choice, but something that would be useful to document.