### PR TITLE
Remove proof-of-possession challenge

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2113,9 +2113,9 @@ response can only be used with the account key for which it was generated.
 An active attacker on the validation channel can subvert the ACME process, by
 performing normal ACME transactions and providing a validation response for his
 own account key.  The risks due to hosting providers noted above are a
-particular case.  For identifiers where the server already has some credential
+particular case.  For identifiers where the server already has some public key
 associated with the domain this attack can be prevented by requiring the client
-to complete a proof-of-possession challenge.
+to prove control of the corresponding private key.
 
 ## Preventing Authorization Hijacking
 


### PR DESCRIPTION
There has been no implementer interest in the proof-of-possession challenge, and it makes the document more complex by having a completely different structure than the other challenges.  If it is decided later that such a challenge is necessary, it can be added in a follow-on extension specificiation.