### PR TITLE
Add section about rate limits

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -537,15 +537,9 @@ indicate why the server was unable to validate authorization.
 
 ## Rate limits
 
-Creation of resources can be rate limited to ensure fair usage and prevent abuse. If rate limits are in place, the server SHOULD send the following three headers fields:
+Creation of resources can be rate limited to ensure fair usage and prevent abuse.  Once the rate limit is exceeded, the server MUST respond with an error with the code "rateLimited".  Additionally, the server SHOULD send a "Retry-After" header indicating when the current request may succeed again.  If multiple rate limits are in place, that is the time where all rate limits allow access again for the current request with exactly the same parameters.
 
-| Header name           | Value                                         |
-|:----------------------|:----------------------------------------------|
-| RateLimit-Limit       | Total limit in the given time window.         |
-| RateLimit-Remaining   | Remaining creations in the given time window. |
-| RateLimit-Reset       | Time in seconds until the limit is reset.     |
-
-Once the rate limit is exceeded, the server responds with an error with the code "rateLimited".
+In addition to the human readable "detail" field of the error response, the server MAY send one or multiple tokens in the "Link" header pointing to documentation about the specific hit rate limits using the "rate-limit" relation.
 
 ## Replay protection
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -535,6 +535,18 @@ namespace for errors other than the standard types.  Clients SHOULD display the
 Authorization and challenge objects can also contain error information to
 indicate why the server was unable to validate authorization.
 
+## Rate limits
+
+Creation of resources can be rate limited to ensure fair usage and prevent abuse. If rate limits are in place, the server SHOULD send the following three headers fields:
+
+| Header name           | Value                                         |
+|:----------------------|:----------------------------------------------|
+| RateLimit-Limit       | Total limit in the given time window.         |
+| RateLimit-Remaining   | Remaining creations in the given time window. |
+| RateLimit-Reset       | Time in seconds until the limit is reset.     |
+
+Once the rate limit is exceeded, the server responds with an error with the code "rateLimited".
+
 ## Replay protection
 
 In order to protect ACME resources from any possible replay attacks, ACME


### PR DESCRIPTION
Rate limits can be used to show warnings to the user, e.g. when certificate issuance is limited to 5 certificates per 7 days and you already issued 3. A single client can't count these, because they may be on different servers using different clients.