### PR TITLE
Remove 'date' field from metadata

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2,7 +2,6 @@
 title: "Automatic Certificate Management Environment (ACME)"
 abbrev: ACME
 docname: draft-ietf-acme-acme-02
-date: 2015-10-04
 category: std
 ipr: trust200902
 


### PR DESCRIPTION
This will cause the date in XML/TXT format to be auto-generated at build time, so that we won't get submit errors about the date being too old.