### PR TITLE
Account compromise mitigations

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2252,3 +2252,4 @@ inception.
 This document draws on many concepts established by Eric Rescorla's "Automated
 Certificate Issuance Protocol" draft.  Martin Thomson provided helpful guidance
 in the use of HTTP.
+


### PR DESCRIPTION
Based on the mailing list thread "[Acme] [acme] Account deletion for security currently useless if rolled over".

Short reasons: Not too long ago, the possibility for deleting accounts was introduced. Partially this, partially the account key rollover, has some problems in case the account key gets lost/stolen/anything. 

Basically, this is for preventing the attacker from deleting/rekeying/... the account to prevent the rightful owner from revoking/deleting the new "evil" certificates.

Sorry, it got quite a lot.