### PR TITLE
Fix typo in JSON authorization object.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1034,7 +1034,7 @@ Link: <https://example.com/acme/some-directory>;rel="directory"
       "uri": "https://example.com/authz/asdf/1",
       "token": "DGyRejmCefe7v4NfDGDKfA"
     }
-  },
+  ],
 
   "combinations": [[0], [1]]
 }


### PR DESCRIPTION
Field "challenges" is associated to a json list.
The representation of this list starts square bracket "[", but it is closed with
a curly bracket "}".