### PR TITLE
Revert "suggest using DNS over TCP"

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2127,10 +2127,6 @@ perform all necessary checks before issuing.
 
 There are certain factors that arise in operational reality that operators of
 ACME-based CAs will need to keep in mind when configuring their services.
-For example:
-
-* It is advisable to perform DNS queries via TCP to mitigate DNS forgery
-  attacks over UDP
 
 [[ TODO: Other operational considerations ]]
 


### PR DESCRIPTION
This reverts commit 556ab4e0f3ff4d402bea530dee7c22ca9c3306db (pull #75).

Deployment experience has shown that DNS via TCP to remote hosts is too unreliable to use in practice. Let's Encrypt uses DNS via TCP only within its own datacenter, and may stop doing that soon too.