### PR TITLE
Allow user specified revocation reason

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1323,6 +1323,13 @@ certificate (required, string):
 format.  (Note: This field uses the same modified Base64 encoding rules used
 elsewhere in this document, so it is different from PEM.)
 
+reason (optional, int):
+: One of the revocation reasonCodes defined in RFC 5280 {{RFC5280}} Section 5.3.1
+to be used when generating OCSP responses and CRLs. If this field is not set
+the server SHOULD use the unspecified (0) reasonCode value when generating OCSP
+responses and CRLs. The server MAY disallow a subset of reasonCodes from being
+used by the user.
+
 ~~~~~~~~~~
 POST /acme/revoke-cert HTTP/1.1
 Host: example.com
@@ -1330,7 +1337,8 @@ Host: example.com
 /* BEGIN JWS-signed request body */
 {
   "resource": "revoke-cert",
-  "certificate": "MIIEDTCCAvegAwIBAgIRAP8..."
+  "certificate": "MIIEDTCCAvegAwIBAgIRAP8...",
+  "reason": 1
 }
 /* END JWS-signed request body */
 ~~~~~~~~~~


### PR DESCRIPTION
Instead of leaving the behavior undefined allow the user to specify a optional `reason` parameter for the `revoke-cert` resource.