### PR TITLE
Remove Flattened JSON Serialization requirement.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -356,7 +356,6 @@ authentication of requests by way of key continuity.
 
 JWS objects sent in ACME requests MUST meet the following additional criteria:
 
-* The JWS MUST use the Flattened JSON Serialization
 * The JWS MUST be encoded using UTF-8
 * The JWS Header or Protected Header MUST include "alg" and "jwk" fields
 * The JWS MUST NOT have the value "none" in its "alg" field


### PR DESCRIPTION
The multiple signatures used for key rollover require non-flattened form.
