### PR TITLE
Unparallelize signatures on key-change

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -312,11 +312,11 @@ is readable.  Some fields are omitted for brevity, marked with "...".
 
 ## Equivalence of JWKs
 
-At several points in the protocol, it is necessary for the server to compare one
-key to another in JWK form.  In performing these comparisons, the server SHOULD
-consider two JWKs to be equal if they have the same "kty" value and contain
-identical values in the fields used in the computation of a JWK thumbprint for
-that key type:
+At several points in the protocol, it is necessary for the server to determine
+whether two JWK objects represent the same key.  In performing these checks, the
+server SHOULD consider two JWKs to match if and only if they have the same "kty"
+value and contain identical values in the fields used in the computation of a
+JWK thumbprint for that key type:
 
 * "RSA": "n", "e"
 * "EC": "crv", "x", "y"

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -310,6 +310,17 @@ serialization, with the protected header and payload expressed as
 base64url(content) instead of the actual base64-encoded value, so that the content
 is readable.  Some fields are omitted for brevity, marked with "...".
 
+## Equivalence of JWKs
+
+At several points in the protocol, it is necessary for the server to compare one
+key to another in JWK form.  In performing these comparisons, the server SHOULD
+consider two JWKs to be equal if they have the same "kty" value and contain
+identical values in the fields used in the computation of a JWK thumbprint for
+that key type:
+
+* "RSA": "n", "e"
+* "EC": "crv", "x", "y"
+
 ## Request URI Integrity
 
 It is common in deployment the entity terminating TLS for HTTPS to be different
@@ -991,11 +1002,11 @@ exact string provided in the Location header field in response to the
 new-registration request that created the account.
 
 oldKey (required, JWK):
-: The JWK thumbprint of the original key (i.e., the client's current account
+: The JWK representation of the original key (i.e., the client's current account
 key)
 
 newKey (requrired, JWK):
-: The JWK thumbprint of the new key
+: The JWK representation of the new key
 
 Both of these thumbprints MUST be computed as specified in {{!RFC7638}}, using
 the SHA-256 digest.  The values in the "oldKey" and "newKey" fields MUST be the
@@ -1042,8 +1053,8 @@ Content-Type: application/jose+json
     }),
     "payload": base64url({
       "account": "https://example.com/acme/reg/asdf",
-      "oldKey": "bHcFJ3p0fMo5I6Nu9uvx5Yat04ePLpe0UsA40nNyweg",
-      "newKey": "Nyh_IpZjLIiAu_xm4Xp0Ac5Ckd1Gq1p-UtQjhMADCZI"
+      "oldKey": /* old key */,
+      "newKey": /* new key */
     })
     "signature": "Xe8B94RD30Azj2ea...8BmZIRtcSKPSd8gU"
   }),

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -322,12 +322,19 @@ is readable.  Some fields are omitted for brevity, marked with "...".
 
 At several points in the protocol, it is necessary for the server to determine
 whether two JWK objects represent the same key.  In performing these checks, the
-server SHOULD consider two JWKs to match if and only if they have the same "kty"
-value and contain identical values in the fields used in the computation of a
-JWK thumbprint for that key type:
+server MUST consider two JWKs to match if and only if they have the identical
+values in all fields included in the computation of a JWK thumbprint for that
+key. That is, the keys must have the same "kty" value and contain identical
+values in the fields used in the computation of a JWK thumbprint for that key
+type:
 
 * "RSA": "n", "e"
 * "EC": "crv", "x", "y"
+
+Note that this comparison is equivalent to computing the JWK thumbprints of the
+two keys and comparing thumbprints.  The only difference is that there is no
+requirement for a hash computation (and thus it is independent of the choice of
+hash function) and no risk of hash collision.
 
 ## Request URI Integrity
 
@@ -1001,7 +1008,7 @@ oldKey (required, JWK):
 : The JWK representation of the original key (i.e., the client's current account
 key)
 
-newKey (requrired, JWK):
+newKey (required, JWK):
 : The JWK representation of the new key
 
 Both of these thumbprints MUST be computed as specified in {{!RFC7638}}, using


### PR DESCRIPTION
Fixes #148 

As discussed (too ambiguously) at IETF 96, this refactor uses two nested JWS objects instead of one parallel JWS object.

This preserves the pattern that every ACME message sent by the client is signed by exactly one account key, and saves clients from having to search through multiple signatures in the verification process. 