### PR TITLE
Remove certificates field from registration object.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -648,14 +648,6 @@ pending applications, and SHOULD NOT include applications that are invalid. The
 server MAY return an incomplete list, along with a Link header with link
 relation "next" indicating a URL to retrieve further entries.
 
-certificates (required, string):
-: A URI from which a list of certificates issued for this account can be fetched
-via a GET request.  The result of the GET request MUST be a JSON object whose
-"certificates" field is an array of strings, where each string is the URI of a
-certificate.  The server SHOULD NOT include expired or revoked certificates.
-The server MAY return an incomplete list, along with a Link header with link
-relation "next" indicating a URL to retrieve further entries.
-
 ~~~~~~~~~~
 {
   "contact": [


### PR DESCRIPTION
The registration object already contains a list of certificate applications, and
each application contains a link to the resulting certificate if one was issued.
This reduces the number of primitives that an ACME server has to support.