### PR TITLE
Clarify "new-X" resources paragraph.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -490,9 +490,9 @@ ACME is structured as a REST application with a few types of resources:
 * A "revoke-certificate" resource
 * A "key-change" resource
 
-For the "new-X" resources above, the server MUST have exactly one resource for
-each function.  This resource may be addressed by multiple URIs, but all must
-provide equivalent functionality.
+For the singular resources above ("directory", "new-registration",
+"new-application", "revoke-certificate", and "key-change") the resource may be
+addressed by multiple URIs, but all must provide equivalent functionality.
 
 ACME uses different URIs for different management functions. Each function is
 listed in a directory along with its corresponding URI, so clients only need to


### PR DESCRIPTION
Prior to this PR the specification seems to be contradictory, indicating that the "new-X" resources must not be duplicated, but that they can live at different URIs. It's not clear to me what this MUST is trying to prevent, especially in light of an allowance of multiple URIs if functionality is equivalent.

Similarly, while the text prior to this PR says "new-X" I believe the intentions of the statements that follow would include some of the resources that have been added since, e.g. "key-change".

This PR updates the "new-X" language to include the additional singular resources and removes the MUST.

If I've missed the mark in this clarification perhaps someone who was involved with the spec at the time of this paragraph's writing can help guide us to something both clear & accurate to the original spirit. 