### PR TITLE
Clarify flows around agreement to terms

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1020,9 +1020,9 @@ That is, it should send a JWS whose payload is trivial ({}).
 
 ### Agreement to Terms of Service
 
-As described above, a client can indicate its agreement with a specific set of
-terms (referenced by URL) by indicating that URL in the "agreement" field of its
-registration object.
+As described above, a client can indicate its agreement with the CA's terms of
+service by setting the "terms-of-service-agreed" field in its registration
+object to "true".
 
 If a client has not agreed to the server's terms of service and the server is
 unwilling to process a request without agreement, then it MUST return an error
@@ -1033,15 +1033,15 @@ terms-of-service URL.
 
 If a client receives an "agreementRequired" error and is willing to agree to the
 terms of service referenced in the Link header, then it SHOULD update its
-registration with the new agreement URL and retry the original request.
+registration to indicate its agreement, then retry the original request.
 
 The "agreementRequired" error allows CAs to clearly express when agreement to
 terms is required, both for new registrations that have not agreed to any terms,
 and for existing registrations that may have agreed to an older version of the
-terms.  If a CA makes a change to its terms of service or terms-of-service URL
-that does not require action by the client (e.g., simply moving the document to
-a different server), then it SHOULD simply update the agreement URL in existing
-registration objects.
+terms. If a CA makes a change to its terms of service or terms-of-service URL
+that requires the client to re-agree, then it MUST either remove the
+"terms-of-service-agreed" field from the client's registration object or set it
+to "false".
 
 ### Account Key Roll-over
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -340,9 +340,12 @@ MUST compare the "url" parameter to the request URI.  If the two do not match,
 then the server MUST reject the request as unauthorized.
 
 Except for the directory resource, all ACME resources are addressed with URLs
-provided to the client by the server.  In such cases, the client MUST set the
+provided to the client by the server.  For these resources, the client MUST set the
 "url" field to the exact string provided by the server (rather than performing
-any re-encoding on the URL).
+any re-encoding on the URL).  The server SHOULD perform the corresponding string
+equality check, configuring each resource with the URL string provided to
+clients and having the resource check that requests have the same string in
+their "url" fields.
 
 ### "url" (URL) JWS header parameter
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1001,8 +1001,8 @@ key but not the corresponding registration URI to recover the registration URI.
 If the server wishes to present the client with terms under which the ACME
 service is to be used, it MUST indicate the URI where such terms can be accessed
 in the "terms-of-service" subfield of the "meta" field in the directory object,
-and the server SHOULD reject new-registration requests that do not contain
-"terms-of-service-agreed": true.
+and the server MUST reject new-registration requests that do not have the
+"terms-of-service-agreed" set to "true".
 
 ~~~~~~~~~~
 HTTP/1.1 201 Created
@@ -1060,22 +1060,22 @@ information about its account (e.g., to examine the "contact" or "certificates"
 fields), then it SHOULD do so by sending a POST request with an empty update.
 That is, it should send a JWS whose payload is trivial ({}).
 
-### Agreement to Terms of Service
+### Changes of Terms of Service
 
 As described above, a client can indicate its agreement with the CA's terms of
 service by setting the "terms-of-service-agreed" field in its registration
 object to "true".
 
-If a client has not agreed to the server's terms of service and the server is
-unwilling to process a request without agreement, then it MUST return an error
-response with status code 403 (Forbidden) and type
-"urn:ietf:params:acme:error:agreementRequired".  This response MUST include a
-Link header with link relation "terms-of-service" and the latest
+If the server has changed its terms of service since a client initially agreed,
+and the server is unwilling to process a request without agreement to the new
+terms, then it MUST return an error response with status code 403 (Forbidden)
+and type "urn:ietf:params:acme:error:agreementRequired".  This response MUST
+include a Link header with link relation "terms-of-service" and the latest
 terms-of-service URL.
 
-The server MAY also include an "action" field in the problem document returned
-with the error, indicating a URL that the client should direct a human user to
-visit in order for instructions on how to agree to the terms.
+The problem document returned with the error MUST also include an "instance"
+field, indicating a URL that the client should direct a human user to visit in
+order for instructions on how to agree to the terms.
 
 ~~~~~
 HTTP/1.1 403 Forbidden
@@ -1086,16 +1086,9 @@ Content-Language: en
 {
   "type": "urn:ietf:params:acme:error:agreementRequired"
   "detail": "Terms of service have changed"
-  "action": "http://example.com/agreement/?token=W8Ih3PswD-8"
+  "instance": "http://example.com/agreement/?token=W8Ih3PswD-8"
 }
 ~~~~~
-
-If an "action" field is provided, then the client indicates its agreement by
-visiting the indicated URL.  Otherwise, the client update sits registration to
-set the "terms-of-service-agreed" field to "true".  Note that this latter action
-is only supported for new accounts that have not previously agreed to terms, so
-if a server requires a second agreement on a change of terms, then it MUST
-include an "action" URL when it returns an "agreementRequired" error.
 
 
 ### Account Key Roll-over

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1031,17 +1031,30 @@ response with status code 403 (Forbidden) and type
 Link header with link relation "terms-of-service" and the latest
 terms-of-service URL.
 
-If a client receives an "agreementRequired" error and is willing to agree to the
-terms of service referenced in the Link header, then it SHOULD update its
-registration to indicate its agreement, then retry the original request.
+The server MAY also include an "action" field in the problem document returned
+with the error, indicating a URL that the client should direct a human user to
+visit in order for instructions on how to agree to the terms.
 
-The "agreementRequired" error allows CAs to clearly express when agreement to
-terms is required, both for new registrations that have not agreed to any terms,
-and for existing registrations that may have agreed to an older version of the
-terms. If a CA makes a change to its terms of service or terms-of-service URL
-that requires the client to re-agree, then it MUST either remove the
-"terms-of-service-agreed" field from the client's registration object or set it
-to "false".
+~~~~~
+HTTP/1.1 403 Forbidden
+Replay-Nonce: IXVHDyxIRGcTE0VSblhPzw
+Content-Type: application/problem+json
+Content-Language: en
+
+{
+  "type": "urn:ietf:params:acme:error:agreementRequired"
+  "detail": "Terms of service have changed"
+  "action": "http://example.com/agreement/?token=W8Ih3PswD-8"
+}
+~~~~~
+
+If an "action" field is provided, then the client indicates its agreement by
+visiting the indicated URL.  Otherwise, the client update sits registration to
+set the "terms-of-service-agreed" field to "true".  Note that this latter action
+is only supported for new accounts that have not previously agreed to terms, so
+if a server requires a second agreement on a change of terms, then it MUST
+include an "action" URL when it returns an "agreementRequired" error.
+
 
 ### Account Key Roll-over
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -455,6 +455,7 @@ to errors, this document defines the following standard tokens for use in the
 | invalidContact        | The contact URI for a registration was invalid     |
 | rejectedIdentifier    | The server will not issue for the identifier       |
 | unsupportedIdentifier | Identifier is not supported, but may be in future  |
+| agreementRequired     | The client must agree to terms before proceeding   |
 
 This list is not exhaustive. The server MAY return errors whose "type" field is
 set to a URI other than those defined above.  Servers MUST NOT use the ACME URN
@@ -971,6 +972,31 @@ requests are not authenticated.  If a client wishes to query the server for
 information about its account (e.g., to examine the "contact" or "certificates"
 fields), then it SHOULD do so by sending a POST request with an empty update.
 That is, it should send a JWS whose payload is trivial ({}).
+
+### Agreement to Terms of Service
+
+As described above, a client can indicate its agreement with a specific set of
+terms (referenced by URL) by indicating that URL in the "agreement" field of its
+registration object.
+
+If a client has not agreed to the server's terms of service and the server is
+unwilling to process a request without agreement, then it MUST return an error
+response with status code 403 (Forbidden) and type
+"urn:ietf:params:acme:error:agreementRequired".  This response MUST include a
+Link header with link relation "terms-of-service" and the latest
+terms-of-service URL.
+
+If a client receives an "agreementRequired" error and is willing to agree to the
+terms of service referenced in the Link header, then it SHOULD update its
+registration with the new agreement URL and retry the original request.
+
+The "agreementRequired" error allows CAs to clearly express when agreement to
+terms is required, both for new registrations that have not agreed to any terms,
+and for existing registrations that may have agreed to an older version of the
+terms.  If a CA makes a change to its terms of service or terms-of-service URL
+that does not require action by the client (e.g., simply moving the document to
+a different server), then it SHOULD simply update the agreement URL in existing
+registration objects.
 
 ### Account Key Roll-over
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1067,11 +1067,11 @@ service by setting the "terms-of-service-agreed" field in its registration
 object to "true".
 
 If the server has changed its terms of service since a client initially agreed,
-and the server is unwilling to process a request without agreement to the new
-terms, then it MUST return an error response with status code 403 (Forbidden)
-and type "urn:ietf:params:acme:error:agreementRequired".  This response MUST
-include a Link header with link relation "terms-of-service" and the latest
-terms-of-service URL.
+and the server is unwilling to process a request without explicit agreement to
+the new terms, then it MUST return an error response with status code 403
+(Forbidden) and type "urn:ietf:params:acme:error:agreementRequired".  This
+response MUST include a Link header with link relation "terms-of-service" and
+the latest terms-of-service URL.
 
 The problem document returned with the error MUST also include an "instance"
 field, indicating a URL that the client should direct a human user to visit in


### PR DESCRIPTION
Right now, it's not clear when the client needs to agree to the server's terms, and what the server should do if it needs the client to re-agree.  This PR addresses both with a dedicated error code and some related behaviors.