### PR TITLE
Change 'url' field on OOB challenge to 'href'

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1867,13 +1867,15 @@ providing a URL for that web page.
 type (required, string):
 : The string "oob-01"
 
-url (required, string):
-: The URL to be visited.  The scheme of this URL MUST be "http" or "https"
+href (required, string):
+: The URL to be visited.  The scheme of this URL MUST be "http" or "https".
+Note that this field is distinct from the "uri" field of the challenge, which
+identifies the challenge itself.
 
 ~~~~~~~~~~
 {
   "type": "oob-01",
-  "url": "https://example.com/validate/evaGxfADs6pSRb2LAv9IZ"
+  "href": "https://example.com/validate/evaGxfADs6pSRb2LAv9IZ"
 }
 ~~~~~~~~~~
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1295,12 +1295,12 @@ Link: <https://example.com/acme/some-directory>;rel="directory"
   "challenges": [
     {
       "type": "http-01",
-      "uri": "https://example.com/authz/asdf/0",
+      "url": "https://example.com/authz/asdf/0",
       "token": "IlirfxKKXAsHtmzK29Pj8A"
     },
     {
       "type": "dns-01",
-      "uri": "https://example.com/authz/asdf/1",
+      "url": "https://example.com/authz/asdf/1",
       "token": "DGyRejmCefe7v4NfDGDKfA"
     }
   ],
@@ -1546,8 +1546,8 @@ Challenge objects all contain the following basic fields:
 type (required, string):
 : The type of challenge encoded in the object.
 
-uri (required, string):
-: The URI to which a response can be posted.
+url (required, string):
+: The URL to which a response can be posted.
 
 status (required, string):
 : The status of this authorization.  Possible values are: "pending", "valid",
@@ -1869,7 +1869,7 @@ type (required, string):
 
 href (required, string):
 : The URL to be visited.  The scheme of this URL MUST be "http" or "https".
-Note that this field is distinct from the "uri" field of the challenge, which
+Note that this field is distinct from the "url" field of the challenge, which
 identifies the challenge itself.
 
 ~~~~~~~~~~


### PR DESCRIPTION
To avoid confusion with the `uri` field, which has the URL for the challenge itself.