### PR TITLE
Updates Section 6.1.2 - "Registration Objects" for Applications.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -670,13 +670,9 @@ server (see below).  Including this field indicates the client's agreement with
 the referenced terms.
 
 applications (required, string):
-: A URI from which a list of authorizations submitted by this account can be
-fetched via a GET request.  The result of the GET request MUST be a JSON object
-whose "applications" field is an array of strings, where each string is the URI
-of an authorization belonging to this registration.  The server SHOULD include
-pending applications, and SHOULD NOT include applications that are invalid. The
-server MAY return an incomplete list, along with a Link header with link
-relation "next" indicating a URL to retrieve further entries.
+: An array of URIs from which application objects submitted by this account can
+be fetched via a GET request. The server SHOULD include pending applications,
+and SHOULD NOT include applications that are invalid.
 
 ~~~~~~~~~~
 {
@@ -685,8 +681,10 @@ relation "next" indicating a URL to retrieve further entries.
     "tel:+12025551212"
   ],
   "agreement": "https://example.com/acme/terms",
-  "authorizations": "https://example.com/acme/reg/1/authz",
-  "certificates": "https://example.com/acme/reg/1/cert"
+  "applications": [
+    "https://example.com/acme/reg/1/apps/1",
+    "https://example.com/acme/reg/1/apps/2"
+  ]
 }
 ~~~~~~~~~~
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1048,10 +1048,6 @@ key)
 newKey (required, JWK):
 : The JWK representation of the new key
 
-Both of these thumbprints MUST be computed as specified in {{!RFC7638}}, using
-the SHA-256 digest.  The values in the "oldKey" and "newKey" fields MUST be the
-base64url encodings of the thumbprints.
-
 The client then encapsulates the key-change object in a JWS, signed with the
 client's current account key (i.e., the key matching the "oldKey" value).
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -670,9 +670,8 @@ server (see below).  Including this field indicates the client's agreement with
 the referenced terms.
 
 applications (required, string):
-: An array of URIs from which application objects submitted by this account can
-be fetched via a GET request. The server SHOULD include pending applications,
-and SHOULD NOT include applications that are invalid.
+: A URI from which an array of URIs for application objects submitted by this
+account can be fetched via a GET request.
 
 ~~~~~~~~~~
 {
@@ -681,10 +680,7 @@ and SHOULD NOT include applications that are invalid.
     "tel:+12025551212"
   ],
   "agreement": "https://example.com/acme/terms",
-  "applications": [
-    "https://example.com/acme/reg/1/apps/1",
-    "https://example.com/acme/reg/1/apps/2"
-  ]
+  "applications": "https://example.com/acme/reg/1/apps"
 }
 ~~~~~~~~~~
 
@@ -766,6 +762,8 @@ syntax like "confirm": true ]]
 support reissuance / renewal in a straightforward way, especially if the CSR /
 notBefore / notAfter could be updated. ]]
 
+#### Application Requirements
+
 The elements of the "requirements" array are immutable once set, except for
 their "status" fields.  If any other part of the object changes after the object
 is created, the client MUST consider the application invalid.
@@ -789,7 +787,7 @@ status (required, string):
 
 All additional fields are specified by the requirement type.
 
-#### Authorization Requirement
+##### Authorization Requirement
 
 A requirement with type "authorization" requests that the ACME client complete
 an authorization transaction.  The server specifies the authorization by
@@ -803,7 +801,7 @@ To fulfill this requirement, the ACME client should fetch the authorization obje
 from the indicated URL, then follow the process for obtaining authorization as
 specified in {{identifier-authorization}}.
 
-#### Out-of-Band Requirement
+##### Out-of-Band Requirement
 
 A requirement with type "out-of-band" requests that the ACME client have a
 human user visit a web page in order to receive further instructions for how to
@@ -815,6 +813,30 @@ url (required, string):
 
 To fulfill this requirement, the ACME client should direct the user to the
 indicated web page.
+
+#### Applications List
+
+Each registration object includes an applications URI from which a list of
+applications created by the registration can be fetched via GET request. The
+result of the GET request MUST be a JSON object whose "applications" field is an
+array of URIs, each identifying an applications belonging to the registration.
+The server SHOULD include pending applications, and SHOULD NOT include
+applications that are invalid in the array of URIs. The server MAY return an
+incomplete list, along with a Link header with link relation “next” indicating
+a URL to retrieve further entries.
+
+~~~~~~~~~~
+HTTP/1.1 200 OK
+Content-Type: application/json
+Link: href="/acme/reg/1/apps?cursor=2", rel="next"
+
+{
+  "applications": [
+    "https://example.com/acme/reg/1/apps/1",
+    "https://example.com/acme/reg/1/apps/2"
+  ]
+}
+~~~~~~~~~~
 
 
 ### Authorization Objects

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -798,7 +798,7 @@ status (required, string):
 
 All additional fields are specified by the requirement type.
 
-##### Authorization Requirement
+#### Authorization Requirement
 
 A requirement with type "authorization" requests that the ACME client complete
 an authorization transaction.  The server specifies the authorization by
@@ -812,7 +812,7 @@ To fulfill this requirement, the ACME client should fetch the authorization obje
 from the indicated URL, then follow the process for obtaining authorization as
 specified in {{identifier-authorization}}.
 
-##### Out-of-Band Requirement
+#### Out-of-Band Requirement
 
 A requirement with type "out-of-band" requests that the ACME client have a
 human user visit a web page in order to receive further instructions for how to

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -684,6 +684,30 @@ account can be fetched via a GET request.
 }
 ~~~~~~~~~~
 
+#### Applications List
+
+Each registration object includes an applications URI from which a list of
+applications created by the registration can be fetched via GET request. The
+result of the GET request MUST be a JSON object whose "applications" field is an
+array of URIs, each identifying an applications belonging to the registration.
+The server SHOULD include pending applications, and SHOULD NOT include
+applications that are invalid in the array of URIs. The server MAY return an
+incomplete list, along with a Link header with link relation “next” indicating
+a URL to retrieve further entries.
+
+~~~~~~~~~~
+HTTP/1.1 200 OK
+Content-Type: application/json
+Link: href="/acme/reg/1/apps?cursor=2", rel="next"
+
+{
+  "applications": [
+    "https://example.com/acme/reg/1/apps/1",
+    "https://example.com/acme/reg/1/apps/2"
+  ]
+}
+~~~~~~~~~~
+
 ### Application Objects
 
 An ACME registration resource represents a client's request for a certificate,
@@ -813,31 +837,6 @@ url (required, string):
 
 To fulfill this requirement, the ACME client should direct the user to the
 indicated web page.
-
-#### Applications List
-
-Each registration object includes an applications URI from which a list of
-applications created by the registration can be fetched via GET request. The
-result of the GET request MUST be a JSON object whose "applications" field is an
-array of URIs, each identifying an applications belonging to the registration.
-The server SHOULD include pending applications, and SHOULD NOT include
-applications that are invalid in the array of URIs. The server MAY return an
-incomplete list, along with a Link header with link relation “next” indicating
-a URL to retrieve further entries.
-
-~~~~~~~~~~
-HTTP/1.1 200 OK
-Content-Type: application/json
-Link: href="/acme/reg/1/apps?cursor=2", rel="next"
-
-{
-  "applications": [
-    "https://example.com/acme/reg/1/apps/1",
-    "https://example.com/acme/reg/1/apps/2"
-  ]
-}
-~~~~~~~~~~
-
 
 ### Authorization Objects
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -944,11 +944,11 @@ Content-Type: application/jose+json
 }
 ~~~~~~~~~~
 
-The server MUST ignore any values provided in the "key", "authorizations", and
-"certificates" fields in registration bodies sent by the client, as well as any
-other fields that it does not recognize.  If new fields are specified in the
-future, the specification of those fields MUST describe whether they may be
-provided by the client.
+The server MUST ignore any values provided in the "key", and "applications"
+fields in registration bodies sent by the client, as well as any other fields
+that it does not recognize.  If new fields are specified in the future, the
+specification of those fields MUST describe whether they may be provided by the
+client.
 
 The server creates a registration object with the included contact information.
 The "key" element of the registration is set to the public key used to verify
@@ -990,9 +990,10 @@ Link: <https://example.com/acme/some-directory>;rel="directory"
 
 If the client wishes to update this information in the future, it sends a POST
 request with updated information to the registration URI.  The server MUST
-ignore any updates to the "key", "authorizations, or "certificates" fields, and
-MUST verify that the request is signed with the private key corresponding to the
-"key" field of the request before updating the registration.
+ignore any updates to the "key", or "applications" fields or any other fields it
+does not recognize. The server MUST verify that the request is signed with the
+private key corresponding to the "key" field of the request before updating the
+registration.
 
 For example, to update the contact information in the above registration, the
 client could send the following request:

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -703,7 +703,9 @@ Link: href="/acme/reg/1/apps?cursor=2", rel="next"
 {
   "applications": [
     "https://example.com/acme/reg/1/apps/1",
-    "https://example.com/acme/reg/1/apps/2"
+    "https://example.com/acme/reg/1/apps/2",
+    /* 47 more URLs not shown for example brevity */
+    "https://example.com/acme/reg/1/apps/50"
   ]
 }
 ~~~~~~~~~~


### PR DESCRIPTION
In [Section 6.1.2 "Registration Objects"](https://github.com/ietf-wg-acme/acme/blob/83e2f7985f5921a4ac30b7446dbb9c1d347d69ec/draft-ietf-acme-acme.md#registration-objects) the "applications" field of the registration resource is described in great detail. This is confusing for two reasons:

1. both the text and the example registration object are still using the "authorization" term that applications replace.
2. the text is written as if the applications should be directly embedded in the registration object returned.

This PR addresses both issues by describing the "applications" field as an array of application URIs that the client can fetch. The example "registration" object is updated accordingly.

The note indicating a server SHOULD include pending applications and SHOULD NOT include invalid applications remains as-is. The note indicating a server MAY return an incomplete list is removed - it is more complicated and with only URIs being returned, likely an unneeded optimization.

Finally, in [Section 6.3 "Registration"](https://github.com/ietf-wg-acme/acme/blob/83e2f7985f5921a4ac30b7446dbb9c1d347d69ec/draft-ietf-acme-acme.md#registration) there are three fields that must be ignored by the server in a registration body: key, authorizations and certificates. This should be "key" and "applications" and is updated accordingly.