### PR TITLE
Clarifies TLS port requirement for SNI challenge.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1838,13 +1838,13 @@ of the domain by verifying that the TLS server was configured appropriately,
 using these steps:
 
 1. Compute SAN A and SAN B in the same way as the client.
-2. Open a TLS connection to TCP port 443 the domain name being validated on the
-   requested port, presenting SAN A in the SNI field.  In the ClientHello
-   initiating the TLS handshake, the server MUST include a server\_name
-   extension (i.e., SNI) containing SAN A. The server SHOULD ensure that it does
-   not reveal SAN B in any way when making the TLS connection, such that the
-   presentation of SAN B in the returned certificate proves association with the
-   client.
+2. Open a TLS connection to the domain name being validated, presenting SAN A in
+   the SNI field. This connection MUST be sent to TCP port 443 on the server. In
+   the ClientHello initiating the TLS handshake, the server MUST include
+   a server\_name extension (i.e., SNI) containing SAN A. The server SHOULD
+   ensure that it does not reveal SAN B in any way when making the TLS
+   connection, such that the presentation of SAN B in the returned certificate
+   proves association with the client.
 3. Verify that the certificate contains a subjectAltName extension containing
    dNSName entries of SAN A and SAN B and no other entries.
    The comparison MUST be insensitive to case and ordering of names.


### PR DESCRIPTION
Pull request #200 was recently merged to clarify that HTTP and TLS challenge requests must use port 80 and 443 respectively.

The "TLS with Server Name Indication (TLS SNI)" section was updated to read:

> Open a TLS connection to TCP port 443 the domain name being validated
> on the requested port, presenting SAN A in the SNI field.

This is a typo ("port 443 the domain name") and also still includes the phrase "on the requested port", which is no longer true.

This PR updates the SNI challenge description to fix the typo and to explicitly say that the server MUST use port 443 in the same style/manner as the HTTP edit from #200.