### PR TITLE
Remove the 'requirements' abstraction

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -760,19 +760,12 @@ notAfter (optional, string):
 : The requested value of the notAfter field in the certificate, in the date
 format defined in {{!RFC3339}}
 
-authorizations (required, array):
+authorizations (required, array of string):
 : For pending applications, the authorizations that the client needs to complete
 before the requested certificate can be issued (see
 {{identifier-authorization}}).  For final applications, the authorizations that
-were completed.  Each entry is a dictionary with parameters describing the
-authorization:
-
-  status (required, string):
-  : The status of the authorization.  This field MUST have the same value as it
-  does in the underlying authorization object.
-
-  url (required, string):
-  : A URL from which the authorization can be fetched with a GET request.
+were completed.  Each entry is a URL from which an authorization can be fetched
+with a GET request.
 
 certificate (optional, string):
 : A URL for the certificate that has been issued in response to this
@@ -788,23 +781,17 @@ application.
   "notAfter": "2016-01-08T00:00:00Z",
 
   "authorizations": [
-    {
-      "status": "valid",
-      "url": "https://example.com/acme/authz/1234"
-    },
-    {
-      "status": "pending",
-      "url": "https://example.com/acme/authz/2345"
-    }
+    "https://example.com/acme/authz/1234",
+    "https://example.com/acme/authz/2345"
   ]
 
   "certificate": "https://example.com/acme/cert/1234"
 }
 ~~~~~~~~~~
 
-The elements of the "authorizations" array are immutable once set, except for
-their "status" fields.  If any other part of the object changes after the object
-is created, the client MUST consider the application invalid.
+The elements of the "authorizations" array are immutable once set. If any change
+is made to the array after the object is created, the client MUST consider the
+application invalid.
 
 The "authorizations" array in the challenge SHOULD reflect all authorizations
 that the CA takes into account in deciding to issue, even if some authorizations
@@ -1250,14 +1237,8 @@ Location: https://example.com/acme/app/asdf
   "notAfter": "2016-01-08T00:00:00Z",
 
   "authorizations": [
-    {
-      "status": "valid",
-      "url": "https://example.com/acme/authz/1234"
-    },
-    {
-      "status": "pending",
-      "url": "https://example.com/acme/authz/2345"
-    }
+    "https://example.com/acme/authz/1234",
+    "https://example.com/acme/authz/2345"
   ]
 }
 ~~~~~~~~~~
@@ -1265,12 +1246,12 @@ Location: https://example.com/acme/app/asdf
 The application object returned by the server represents a promise that if the
 client fulfills the server's requirements before the "expires" time, then the
 server will issue the requested certificate.  In the application object, any
-object in the "authorizations" array whose status is "pending" represents an
-authorization transaction that the client must complete before the server will
-issue the certificate (see {{identifier-authorization}}).  If the client fails
-to complete the required actions before the "expires" time, then the server
-SHOULD change the status of the application to "invalid" and MAY delete the
-application resource.
+authorization referenced in the "authorizations" array whose status is "pending"
+represents an authorization transaction that the client must complete before the
+server will issue the certificate (see {{identifier-authorization}}).  If the
+client fails to complete the required actions before the "expires" time, then
+the server SHOULD change the status of the application to "invalid" and MAY
+delete the application resource.
 
 The server MUST issue the requested certificate and update the application
 resource with a URL for the certificate as soon as the client has fulfilled the
@@ -1279,8 +1260,7 @@ requirements at the time of this request (e.g., by obtaining authorization for
 all of the identifiers in the certificate in previous transactions), then the
 server MUST proactively issue the requested certificate and provide a URL for it
 in the "certificate" field of the application.  The server MUST, however, still
-list the completed authorizations in the "authorizations" array, with the state
-"valid".
+list the completed authorizations in the "authorizations" array.
 
 Once the client believes it has fulfilled the server's requirements, it should
 send a GET request to the application resource to obtain its current state.  The

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -189,7 +189,7 @@ Once the client is registered, there are three major steps it needs to take to
 get a certificate:
 
 1. Apply for a certificate to be issued
-2. Prove control of any identifiers requested in the certificate
+2. Prove control of all identifiers requested in the certificate
 3. Await issuance and download the issued certificate
 
 The client's application for a certificate describes the desired certificate
@@ -762,7 +762,7 @@ format defined in {{!RFC3339}}
 
 authorizations (required, array):
 : For pending applications, the authorizations that the client needs to complete
-before the requested certificate can be granted (see
+before the requested certificate can be issued (see
 {{identifier-authorization}}).  For final applications, the authorizations that
 were completed.  Each entry is a dictionary with parameters describing the
 authorization:


### PR DESCRIPTION
As discussed at IETF 97, this PR removes the "requirements" abstraction, and changes the "requirements" field in an application/order object to be an "authorizations" field.

This is a replacement for #195.