### PR TITLE
Provide more specification for how servers handle unknown fields

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -940,6 +940,11 @@ that it does not recognize.  If new fields are specified in the future, the
 specification of those fields MUST describe whether they may be provided by the
 client.
 
+In general, the server MUST ignore any fields in the request object that it does
+not recognize.  In particular, it MUST NOT reflect unrecognized fields in the
+resulting account object.  This allows clients to detect when servers do not
+support an extension field.
+
 The server SHOULD validate that the contact URLs in the "contact" field are
 valid and supported by the server.  If the client provides the server with an
 invalid or unsupported contact URL, then the server MUST return an error of type


### PR DESCRIPTION
In some cases, it might be important for a client to know that a server has or has not processed an extension field.  For example, if we had an extension that requested some higher level of assurance, then a client would want to know that the CA was going to provide that level of assurance.  This PR specifies some rudimentary feature detection to support this objective.