### PR TITLE
Updated order object registry authorizations field

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -780,13 +780,6 @@ before the requested certificate can be issued (see
 were completed.  Each entry is a URL from which an authorization can be fetched
 with a GET request.
 
-  status (required, string):
-  : The status of the authorization.  This field MUST have the same value as it
-  does in the underlying authorization object.
-
-  url (required, string):
-  : A URL from which the authorization can be fetched with a GET request.
-
 certificate (optional, string):
 : A URL for the certificate that has been issued in response to this order.
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2317,7 +2317,7 @@ Initial contents: The fields and descriptions defined in {{order-objects}}.
 | csr            | string              | true         | RFC XXXX  |
 | notBefore      | string              | true         | RFC XXXX  |
 | notAfter       | string              | true         | RFC XXXX  |
-| authorizations | array of dictionary | false        | RFC XXXX  |
+| authorizations | array of string     | false        | RFC XXXX  |
 | certificate    | string              | false        | RFC XXXX  |
 
 ### Error Codes


### PR DESCRIPTION
The Order Object registry seems to indicate that authorizations is an array of dictionary. However, it has changed to array of string. This PR ensures that the Order Objects registry reflects this change.