### PR TITLE
Clarifies allowed fields in stub account objects

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -912,7 +912,7 @@ caching of this resource.
 
 A client creates a new account with the server by sending a POST request to the
 server's new-account URI.  The body of the request is a stub account object
-containing only the "contact" field.
+containing only the "contact" and optionally the "terms-of-service-agreed" field.
 
 ~~~~~~~~~~
 POST /acme/new-account HTTP/1.1


### PR DESCRIPTION
In accordance with

```
terms-of-service-agreed (optional, boolean):
: Including this field in a new-account request [...]
```