### PR TITLE
Remove SHOULD for HPKP.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -259,8 +259,7 @@ integrity for the HTTPS request URI.
 
 Each ACME function is accomplished by the client sending a sequence of HTTPS
 requests to the server, carrying JSON messages {{!RFC2818}}{{!RFC7159}}.  Use of
-HTTPS is REQUIRED.  Clients SHOULD support HTTP public key pinning {{?RFC7469}},
-and servers SHOULD emit pinning headers.  Each subsection of
+HTTPS is REQUIRED. Each subsection of
 {{certificate-management}} below describes the message formats used by the
 function, and the order in which messages are sent.
 


### PR DESCRIPTION
Public key pinning isn't implemented in most HTTPS libraries outside of
browsers, so this is a considerable burden on implementers.

Public key pinning carries a fairly high risk of footgunning. The
consequence of a failed pin for a CA that serves many ACME clients
would be that some of those clients would fail to renew their certs,
causing cascading breakage.

There is relatively little confidential information conveyed in ACME,
and there are other defenses built into ACME (like including the account
key as part of the challenge data), so HPKP is not strongly necessary.