### PR TITLE
Remove extraneous link relations and change 'directory' to 'index'

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -477,8 +477,8 @@ the current request with exactly the same parameters.
 
 In addition to the human readable "detail" field of the error response, the
 server MAY send one or multiple tokens in the "Link" header pointing to
-documentation about the specific hit rate limits using the "rate-limit"
-relation.
+documentation about the specific hit rate limits using the
+"urn:ietf:params:acme:documentation" relation.
 
 ## Errors
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -565,7 +565,7 @@ certificate resources to indicate a resource from which the client may fetch a
 chain of CA certificates that could be used to validate the certificate in the
 original resource.
 
-The "directory" link relation is present on all resources other than the
+The "index" link relation is present on all resources other than the
 directory and indicates the directory URL.
 
 The following diagram illustrates the relations between resources on an ACME
@@ -578,15 +578,15 @@ indicate HTTP link relations.
                                    |
                                    |--> new-nonce
                                    |
-       --------------------------------------------------+
-       |          |          |                           |
-       |          |          |                           |
-       V          V          V                           V
- new-account  new-authz  new-order                  revoke-cert
-       |          |          |                           ^
-       |          |          |    "author"               | "revoke"
-       V          |          V   <--------               |
-      acct        |        order --------> cert ---------+
+       ----------------------------------+
+       |          |          |           |
+       |          |          |           |
+       V          V          V           V
+ new-account  new-authz  new-order  revoke-cert
+       |          |          |
+       |          |          |
+       V          |          V
+      acct        |        order --------> cert
                   |         | ^              |
                   |         | | "up"         | "up"
                   |         V |              V
@@ -993,7 +993,7 @@ HTTP/1.1 201 Created
 Content-Type: application/json
 Replay-Nonce: D8s4D2mLs8Vn-goWuPQeKA
 Location: https://example.com/acme/acct/1
-Link: <https://example.com/acme/some-directory>;rel="directory"
+Link: <https://example.com/acme/some-directory>;rel="index"
 
 {
   "key": { /* JWK from JWS header */ },
@@ -1496,17 +1496,6 @@ chain starting with the same end-entity certificate. This can be used to express
 paths to various trust anchors. Clients can fetch these alternates and use their
 own heuristics to decide which is optimal.
 
-The server MUST also provide a link relation header field with relation "author"
-to indicate the order under which this certificate was issued.
-
-If the CA participates in Certificate Transparency (CT) {{?RFC6962}}, then they
-may want to provide the client with a Signed Certificate Timestamp (SCT) that
-can be used to prove that a certificate was submitted to a CT log.  An SCT can
-be included as an extension in the certificate or as an extension to OCSP
-responses for the certificate.  The server can also provide the client with
-direct access to an SCT for a certificate using a Link relation header field
-with relation "ct-sct".
-
 ~~~~~~~~~~
 GET /acme/cert/asdf HTTP/1.1
 Host: example.com
@@ -1515,10 +1504,7 @@ Accept: application/pkix-cert
 HTTP/1.1 200 OK
 Content-Type: application/pkix-cert
 Link: <https://example.com/acme/ca-cert>;rel="up";title="issuer"
-Link: <https://example.com/acme/revoke-cert>;rel="revoke"
-Link: <https://example.com/acme/order/asdf>;rel="author"
-Link: <https://example.com/acme/sct/asdf>;rel="ct-sct"
-Link: <https://example.com/acme/some-directory>;rel="directory"
+Link: <https://example.com/acme/some-directory>;rel="index"
 
 -----BEGIN CERTIFICATE-----
 [End-entity certificate contents]
@@ -1575,7 +1561,7 @@ Host: example.com
 
 HTTP/1.1 200 OK
 Content-Type: application/json
-Link: <https://example.com/acme/some-directory>;rel="directory"
+Link: <https://example.com/acme/some-directory>;rel="index"
 
 {
   "status": "pending",


### PR DESCRIPTION
As they are all fulfilled by the `directory` endpoint and are unnecessary. The `ct-sct` relation is removed as the SCT will be provided by the CA via the certificate or a OCSP response, if it doesn't provide these then the client should be able to retrieve the SCT itself from the logs it expects to find the certificate in (or submit it itself).

Also removes a paragraph about Certificate Transparency from the 'Downloading the Certificate' section as it is irrelevant to the section and discusses operations of the CA unrelated to the ACME protocol.

Additionally changes the relation `rate-limit` which is not registered with a URI extension using the ACME URN namespace `urn:ietf:params:acme:documentation`.