### PR TITLE
Update errors and add an error field to orders.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -509,7 +509,7 @@ resources:
 |:----------------------|:-------------------------------------------------------------------|
 | caa                   | CAA records forbid the CA from issuing                             |
 | connection            | The server could not connect to validation target                  |
-| dns                   | There was a problem with a DNS query during validation             |
+| dns                   | There was a problem with a DNS query                               |
 | rateLimited           | The request exceeds a rate limit                                   |
 | serverInternal        | The server experienced an internal error                           |
 | incorrectResponse     | Response received didn't match the challenge's requirements        |
@@ -517,13 +517,12 @@ resources:
 
 Error types that may be commonly included in the "error" field of order
 resources:
-| unknownHost           | The server could not resolve a domain name                         |
-| unsupportedIdentifier | Identifier is not supported but may be in the future               |
-| userActionRequired    | The user visit the "instance" URL and take actions specified there |
 
 | Type                  | Description                                                        |
 |:----------------------|:-------------------------------------------------------------------|
 | caa                   | CAA records forbid the CA from issuing                             |
+| dns                   | There was a problem with a DNS query                               |
+| unsupportedIdentifier | Identifier is not supported but may be in the future               |
 | serverInternal        | The server experienced an internal error                           |
 
 These lists are not exhaustive. The server MAY return errors whose "type" field is

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -483,9 +483,7 @@ server MAY return status code 405 (Method Not Allowed).
 When the server responds with an error status, it SHOULD provide additional
 information using a problem document {{!RFC7807}}.  To facilitate automatic
 response to errors, this document defines the following standard tokens for use
-in the "type" field (within the "urn:ietf:params:acme:error:" namespace).
-
-Error types that may be commonly returned from ACME requests:
+in the "type" field (within the "urn:ietf:params:acme:error:" namespace):
 
 | Type                  | Description                                                        |
 |:----------------------|:-------------------------------------------------------------------|
@@ -501,31 +499,13 @@ Error types that may be commonly returned from ACME requests:
 | unsupportedIdentifier | Identifier is not supported, but may be in future                  |
 | userActionRequired    | Visit the "instance" URL and take actions specified there          |
 | badRevocationReason   | The revocation reason provided is not allowed by the server        |
-
-Error types that may be commonly included in the "error" field of challenge
-resources:
-
-| Type                  | Description                                                        |
-|:----------------------|:-------------------------------------------------------------------|
 | caa                   | CAA records forbid the CA from issuing                             |
+| dns                   | There was a problem with a DNS query                               |
 | connection            | The server could not connect to validation target                  |
-| dns                   | There was a problem with a DNS query                               |
-| rateLimited           | The request exceeds a rate limit                                   |
-| serverInternal        | The server experienced an internal error                           |
-| incorrectResponse     | Response received didn't match the challenge's requirements        |
 | tls                   | The server received a TLS error during validation                  |
+| incorrectResponse     | Response received didn't match the challenge's requirements        |
 
-Error types that may be commonly included in the "error" field of order
-resources:
-
-| Type                  | Description                                                        |
-|:----------------------|:-------------------------------------------------------------------|
-| caa                   | CAA records forbid the CA from issuing                             |
-| dns                   | There was a problem with a DNS query                               |
-| unsupportedIdentifier | Identifier is not supported but may be in the future               |
-| serverInternal        | The server experienced an internal error                           |
-
-These lists are not exhaustive. The server MAY return errors whose "type" field is
+This list is not exhaustive. The server MAY return errors whose "type" field is
 set to a URI other than those defined above.  Servers MUST NOT use the ACME URN
 namespace for errors other than the standard types.  Clients SHOULD display the
 "detail" field of all errors.

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -784,10 +784,8 @@ notAfter (optional, string):
 format defined in {{!RFC3339}}.
 
 error (optional, object):
-: The error that occurred while the server was issuing the certificate, if any.
-This field is structured as a problem document {{!RFC7807}}. Note that
-this field is only for errors occurring after authorizations have been
-validated.
+: The error that occurred while processing the order, if any.
+This field is structured as a problem document {{!RFC7807}}.
 
 authorizations (required, array of string):
 : For pending orders, the authorizations that the client needs to complete

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -510,6 +510,14 @@ resources:
 | incorrectResponse     | Response received didn't match the challenge's requirements        |
 | tls                   | The server received a TLS error during validation                  |
 
+Error types that may be commonly included in the "error" field of order
+resources:
+
+| Type                  | Description                                                        |
+|:----------------------|:-------------------------------------------------------------------|
+| caa                   | CAA records forbid the CA from issuing                             |
+| serverInternal        | The server experienced an internal error                           |
+
 These lists are not exhaustive. The server MAY return errors whose "type" field is
 set to a URI other than those defined above.  Servers MUST NOT use the ACME URN
 namespace for errors other than the standard types.  Clients SHOULD display the

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -500,7 +500,7 @@ Error types that may be commonly returned from ACME requests:
 Error types that may be commonly included in the "error" field of challenge
 resources:
 
-| Code                  | Description                                                        |
+| Type                  | Description                                                        |
 |:----------------------|:-------------------------------------------------------------------|
 | caa                   | CAA records forbid the CA from issuing                             |
 | connection            | The server could not connect to validation target                  |

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -414,8 +414,8 @@ invalid, in the same way as a value it had never issued.
 
 When a server rejects a request because its nonce value was unacceptable (or not
 present), it MUST provide HTTP status code 400 (Bad Request), and indicate the
-ACME error code "urn:ietf:params:acme:error:badNonce".  An error response with
-the "badNonce" error code MUST include a Replay-Nonce header with a fresh nonce.
+ACME error type "urn:ietf:params:acme:error:badNonce".  An error response with
+the "badNonce" error type MUST include a Replay-Nonce header with a fresh nonce.
 On receiving such a response, a client SHOULD retry the request using the new
 nonce.
 
@@ -481,7 +481,7 @@ information using problem document {{!RFC7807}}.  To facilitate automatic
 response to errors, this document defines the following standard tokens for use
 in the "type" field (within the "urn:ietf:params:acme:error:" namespace):
 
-| Code                  | Description                                                        |
+| Type                  | Description                                                        |
 |:----------------------|:-------------------------------------------------------------------|
 | badCSR                | The CSR is unacceptable (e.g., due to a short key)                 |
 | badNonce              | The client sent an unacceptable anti-replay nonce                  |
@@ -1304,7 +1304,7 @@ extensionRequest attribute {{!RFC2985}} requesting a subjectAltName extension.
 The server MUST return an error if it cannot fulfill the request as specified,
 and MUST NOT issue a certificate with contents other than those requested.  If
 the server requires the request to be modified in a certain way, it should
-indicate the required changes using an appropriate error code and description.
+indicate the required changes using an appropriate error type and description.
 
 If the server is willing to issue the requested certificate, it responds with a
 201 (Created) response.  The body of this response is an order object reflecting
@@ -2340,7 +2340,7 @@ This document requests that IANA create the following new registries:
 
 1. ACME Account Object Fields ({{iana-account}})
 2. ACME Order Object Fields ({{iana-order}})
-3. ACME Error Codes ({{iana-error}})
+3. ACME Error Types ({{iana-error}})
 4. ACME Resource Types ({{iana-resource}})
 5. ACME Identifier Types ({{iana-identifier}})
 6. ACME Challenge Types ({{iana-challenge}})
@@ -2402,19 +2402,19 @@ Initial contents: The fields and descriptions defined in {{order-objects}}.
 | authorizations | array of string     | false        | RFC XXXX  |
 | certificate    | string              | false        | RFC XXXX  |
 
-### Error Codes {#iana-error}
+### Error Types {#iana-error}
 
 This registry lists values that are used within URN values that are provided in
 the "type" field of problem documents in ACME.
 
 Template:
 
-* Code: The label to be included in the URN for this error, following
+* Type: The label to be included in the URN for this error, following
   "urn:ietf:params:acme:"
 * Description: A human-readable description of the error
 * Reference: Where the error is defined
 
-Initial contents: The codes and descriptions in the table in {{errors}} above,
+Initial contents: The types and descriptions in the table in {{errors}} above,
 with the Reference field set to point to this specification.
 
 ### Resource Types {#iana-resource}

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -479,28 +479,38 @@ server MAY return status code 405 (Method Not Allowed).
 When the server responds with an error status, it SHOULD provide additional
 information using problem document {{!RFC7807}}.  To facilitate automatic
 response to errors, this document defines the following standard tokens for use
-in the "type" field (within the "urn:ietf:params:acme:error:" namespace):
+in the "type" field (within the "urn:ietf:params:acme:error:" namespace).
+
+Error types that may be commonly returned from ACME requests:
 
 | Type                  | Description                                                        |
 |:----------------------|:-------------------------------------------------------------------|
 | badCSR                | The CSR is unacceptable (e.g., due to a short key)                 |
 | badNonce              | The client sent an unacceptable anti-replay nonce                  |
 | badSignatureAlgorithm | The JWS was signed with an algorithm the server does not support   |
-| caa                   | CAA records forbid the CA from issuing                             |
-| connection            | The server could not connect to validation target                  |
-| dnssec                | DNSSEC validation failed                                           |
 | invalidContact        | The contact URI for an account was invalid                         |
 | malformed             | The request message was malformed                                  |
 | rateLimited           | The request exceeds a rate limit                                   |
 | rejectedIdentifier    | The server will not issue for the identifier                       |
 | serverInternal        | The server experienced an internal error                           |
-| tls                   | The server received a TLS error during validation                  |
 | unauthorized          | The client lacks sufficient authorization                          |
-| unknownHost           | The server could not resolve a domain name                         |
 | unsupportedIdentifier | Identifier is not supported, but may be in future                  |
-| userActionRequired    | The user visit the "instance" URL and take actions specified there |
+| userActionRequired    | Visit the "instance" URL and take actions specified there          |
 
-This list is not exhaustive. The server MAY return errors whose "type" field is
+Error types that may be commonly included in the "error" field of challenge
+resources:
+
+| Code                  | Description                                                        |
+|:----------------------|:-------------------------------------------------------------------|
+| caa                   | CAA records forbid the CA from issuing                             |
+| connection            | The server could not connect to validation target                  |
+| dns                   | There was a problem with a DNS query during validation             |
+| rateLimited           | The request exceeds a rate limit                                   |
+| serverInternal        | The server experienced an internal error                           |
+| incorrectResponse     | Response received didn't match the challenge's requirements        |
+| tls                   | The server received a TLS error during validation                  |
+
+These lists are not exhaustive. The server MAY return errors whose "type" field is
 set to a URI other than those defined above.  Servers MUST NOT use the ACME URN
 namespace for errors other than the standard types.  Clients SHOULD display the
 "detail" field of all errors.
@@ -764,6 +774,12 @@ format defined in {{!RFC3339}}.
 notAfter (optional, string):
 : The requested value of the notAfter field in the certificate, in the date
 format defined in {{!RFC3339}}.
+
+error (optional, object):
+: The error that occurred while the server was issuing the certificate, if any.
+This field is structured as a problem document {{!RFC7807}}. Note that
+this field is only for errors occurring after authorizations have been
+validated.
 
 authorizations (required, array of string):
 : For pending orders, the authorizations that the client needs to complete

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -37,12 +37,12 @@ normative:
 
 --- abstract
 
-Certificates in the Web's X.509 PKI (PKIX) are used for a number of purposes,
+Certificates in PKI using X.509 (PKIX) are used for a number of purposes,
 the most significant of which is the authentication of domain names.  Thus,
 certificate authorities in the Web PKI are trusted to verify that an applicant
 for a certificate legitimately represents the domain name(s) in the certificate.
 Today, this verification is done through a collection of ad hoc mechanisms.
-This document describes a protocol that a certificate authority (CA) and an
+This document describes a protocol that a certification authority (CA) and an
 applicant can use to automate the process of verification and certificate
 issuance.  The protocol also provides facilities for other certificate
 management functions, such as certificate revocation.
@@ -60,7 +60,7 @@ discussed on the ACME mailing list (acme@ietf.org).
 
 # Introduction
 
-Certificates in the Web PKI {{!RFC5280}} are most commonly used to authenticate
+Certificates {{!RFC5280}} in the Web PKI are most commonly used to authenticate
 domain names.  Thus, certificate authorities in the Web PKI are trusted to
 verify that an applicant for a certificate legitimately represents the domain
 name(s) in the certificate.
@@ -114,8 +114,8 @@ for one or more domains, and the process of certificate issuance is intended to
 verify that this server actually speaks for the domain(s).
 
 DV certificate validation commonly checks claims about properties related to
-control of a domain name -- properties that can be observed by the issuing
-authority in an interactive process that can be conducted purely online.  That
+control of a domain name -- properties that can be observed by the certificate
+issuer in an interactive process that can be conducted purely online.  That
 means that under typical circumstances, all steps in the request, verification,
 and issuance process can be represented and performed by Internet protocols with
 no out-of-band human intervention.
@@ -159,7 +159,7 @@ The two main roles in ACME are “client” and “server”.  The ACME client u
 protocol to request certificate management actions, such as issuance or
 revocation.  An ACME client therefore typically runs on a web server, mail
 server, or some other server system which requires valid TLS certificates.  The
-ACME server runs at a certificate authority, and responds to client requests,
+ACME server runs at a certification authority, and responds to client requests,
 performing the requested actions if the client is authorized.
 
 An ACME client is represented by an "account key pair".  The client uses the
@@ -298,7 +298,8 @@ character set. Trailing '=' characters MUST be stripped.
 ## Request Authentication
 
 All ACME requests with a non-empty body MUST encapsulate their payload
-in a JWS object, signed (in most cases) using the account's private
+in a JSON Web Signature (JWS) {{!RFC7515}} object, signed (in most
+cases) using the account's private
 key.  The server MUST verify the JWS before processing the request.
 Encapsulating request bodies in JWS provides a simple authentication
 of requests.
@@ -334,23 +335,10 @@ and type "urn:ietf:params:acme:error:badSignatureAlgorithm".  The problem
 document returned with the error MUST include an "algorithms" field with an
 array of supported "alg" values.
 
-~~~~~
-HTTP/1.1 400 Bad Request
-Replay-Nonce: IXVHDyxIRGcTE0VSblhPzw
-Content-Type: application/problem+json
-Content-Language: en
-
-{
-  "type": "urn:ietf:params:acme:error:badSignatureAlgorithm",
-  "detail": "Algorithm 'ES384' is not supported",
-  "algorithms": ["RS256", "RS384", "ES256"]
-}
-~~~~~
-
 In the examples below, JWS objects are shown in the JSON or flattened JSON
 serialization, with the protected header and payload expressed as
 base64url(content) instead of the actual base64-encoded value, so that the content
-is readable.  Some fields are omitted for brevity, marked with "...".
+is readable.
 
 ## Equivalence of JWKs
 
@@ -633,7 +621,7 @@ There is no constraint on the actual URI of the directory except that it
 should be different from the other ACME server resources' URIs, and that it
 should not clash with other services. For instance:
 
- * a host which function as both an ACME and Web server may want to keep
+ * a host which functions as both an ACME and Web server may want to keep
    the root path "/" for an HTML "front page", and and place the ACME
    directory under path "/acme".
 
@@ -682,7 +670,7 @@ Content-Type: application/json
 
 ### Account Objects
 
-An ACME account resource represents a set of metadata associated to an account.
+An ACME account resource represents a set of metadata associated with an account.
 Account resources have the following structure:
 
 key (required, dictionary):
@@ -850,7 +838,7 @@ scope (optional, string):
 : If this field is present, then it MUST contain a URI for an order resource,
 such that this authorization is only valid for that resource.  If this field is
 absent, then the CA MUST consider this authorization valid for all orders until
-the authorization expires. \[\[ Open issue: More flexible scoping? ]]
+the authorization expires.
 
 challenges (required, array):
 : The challenges that the client can fulfill in order to prove possession of the
@@ -1485,8 +1473,8 @@ specified by {{!RFC7468}}. This format should contain the end-entity certificate
 first, followed by any intermediate certificates that are needed to build a path
 to a trusted root. Servers SHOULD NOT include self-signed trust anchors. The
 client may request other formats by including an Accept header in its request.
-For example, the client could use the media type `application/pkix-cert` to
-request the end-entity certificate in DER format.
+For example, the client could use the media type `application/pkix-cert`
+{{!RFC2585}} to request the end-entity certificate in DER format.
 
 The server MAY provide one or more link relation header fields {{RFC5988}} with
 relation "alternate". Each such field should express an alternative certificate
@@ -1546,7 +1534,7 @@ server of two things:
 
 1. That the client controls the private key of the account key pair, and
 
-2. that the client controls the identifier in question.
+2. That the client controls the identifier in question.
 
 This process may be repeated to associate multiple identifiers to a key pair
 (e.g., to request certificates with multiple identifiers), or to associate
@@ -1922,7 +1910,7 @@ responds for that domain name.  The ACME server challenges the client to
 provision a file at a specific path, with a specific string as its content.
 
 As a domain may resolve to multiple IPv4 and IPv6 addresses, the server will
-connect to at least one of the hosts found in A and AAAA records, at its
+connect to at least one of the hosts found in the DNS A and AAAA records, at its
 discretion.  Because many webservers allocate a default HTTPS virtual host to a
 particular low-privilege tenant user in a subtle and non-intuitive manner, the
 challenge must be completed over HTTP, not HTTPS.
@@ -2018,7 +2006,7 @@ failed.
 
 The TLS with Server Name Indication (TLS SNI) validation method
 proves control over a domain name by requiring the client to configure a TLS
-server referenced by an A/AAAA record under the domain name to respond to
+server referenced by the DNS A and AAAA resource records under the domain name to respond to
 specific connection attempts utilizing the Server Name Indication extension
 {{!RFC6066}}. The server verifies the client's challenge by accessing the
 reconfigured server and verifying a particular challenge certificate is
@@ -2551,7 +2539,7 @@ any individual channel.  Some vulnerabilities arise (noted below), when an
 attacker can exploit both the ACME channel and one of the others.
 
 On the ACME channel, in addition to network-layer attackers, we also need to
-account for application-layer man in the middle attacks, and for abusive use of
+account for application-layer man-in-the-middle (MitM) attacks, and for abusive use of
 the protocol itself.  Protection against application-layer MitM addresses
 potential attackers such as Content Distribution Networks (CDNs) and middleboxes
 with a TLS MitM function.  Preventing abusive use of ACME means ensuring that an


### PR DESCRIPTION
Removes dnssec error type for a broader "dns" error type. It's very hard to split out dnssec errors from regular dns problems, because recursive resolvers can only return SERVFAIL. The new dns error type also subsumes "unknownHost."

Introduces a new "incorrectResponse" error type for cases where connection and request were both successful, but the content didn't match.

This also puts the validation-related errors at the bottom of the table so they can be viewed in context with each other.

Introduces an error field for orders. Orders can fail independent of authorizations because of last-minute CAA checking, failure to submit to CT logs, timeouts, etc.