### PR TITLE
Accounts: Structure and fixes underspecification

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -954,7 +954,7 @@ agreement to terms.
 The server creates an account and stores the public key used to verify the
 JWS (i.e., the "jwk" element of the JWS header) to authenticate future requests
 from the account.  The server returns this account object in a 201 (Created)
-response, with the account URI in a Location header field.
+response, with the account URL in a Location header field.
 
 ~~~~~~~~~~
 HTTP/1.1 201 Created

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -901,8 +901,7 @@ caching of this resource.
 A client creates a new account with the server by sending a POST request to the
 server's new-account URI.  The body of the request is a stub account object
 containing the "contact" field and optionally the "terms-of-service-agreed"
-field.  The server MUST reject new account requests whose JWS payload is an
-empty object ({}).
+field.
 
 ~~~~~~~~~~
 POST /acme/new-account HTTP/1.1

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -973,12 +973,12 @@ Link: <https://example.com/acme/some-directory>;rel="index"
 }
 ~~~~~~~~~~
 
-### Account URI Recovery
+### Finding an Account URL Given a Key
 
 If the server already has an account registered with the provided account key,
-then it MUST return a response with a 200 (OK) status code and provide the URI of
+then it MUST return a response with a 200 (OK) status code and provide the URL of
 that account in the Location header field.  This allows a client that has
-an account key but not the corresponding account URI to recover the account URI.
+an account key but not the corresponding account URL to recover the account URL.
 
 If a client wishes to recover an existing account and does not want a non
 existing account to be created, then it SHOULD do so by sending a POST


### PR DESCRIPTION
This PR is a first go at addressing the following points I raised on the mailing list.

> 1.
>   I cannot find where the response to account updates is specified.
> 
>   Boulder replies with "202 Accepted" and an account object. Since
>   updates with trivial payload should be used for account information,
>   it seems to be expected that an account object is returned. The
>   specified response status for "Account deactivation" is "200 OK".
>   It would be consistent to specify the same response status for
>   account updates I guess?
> 
> 2.
>   The client should be able to choose between "Account URI recovery"
>   and "Account Creation", if needed. A possible way would be to clarify
>   that account creations with trivial payload MUST be rejected. However,
>   if an account exists, the "Content-Location" header and "200 OK" is
>   returned, independent of the payloads content. Therefore a trivial
>   payload could be used to check if an account with the used key exists,
>   without creating it.
> 
> 3.
>   As "6.3.4.  Account deactivation", other queries should get their own
>   sub-sub sections. Something like
>    - "6.3.x Account URI recovery" ("new-account", maybe trivial payload)
>    - "6.3.x Account update"
>    - "6.3.x Account information" (update with trivial payload)
