### PR TITLE
Normalizes 'revoke-cert', 'account'.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -524,7 +524,7 @@ ACME is structured as a REST application with the following types of resources:
 * A "new-nonce" resource ({{getting-a-nonce}})
 * A "new-account" resource ({{account-creation}})
 * A "new-order" resource ({{applying-for-certificate-issuance}})
-* A "revoke-certificate" resource ({{certificate-revocation}})
+* A "revoke-cert" resource ({{certificate-revocation}})
 * A "key-change" resource ({{account-key-roll-over}})
 
 The server MUST provide "directory" and "new-nonce" resources.
@@ -561,7 +561,7 @@ indicate HTTP link relations.
        |          |          |
        |          |          |
        V          |          V
-      acct        |        order --------> cert
+    account       |        order --------> cert
                   |         | ^              |
                   |         | | "up"         | "up"
                   |         V |              V


### PR DESCRIPTION
Fixes per feedback [from Niklas Keller on the mailing list](https://mailarchive.ietf.org/arch/msg/acme/gzXfgzdRht8IW4RBL8kDZuISzdU).

Section 6.1 referenced "revoke-certificate" where elsewhere using
"revoke-cert", this commit replaces it with "revoke-cert".

Section 7.1 has a resource diagram that previously labelled the
termination of the "new-account" flow as "acct", this commit replaces
that label with "account". Elsewhere the use of "acct" is limited to
URLs and not referencing specific resources/spec content.