### PR TITLE
Rewords token entropy justification.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1866,7 +1866,7 @@ type (required, string):
 
 token (required, string):
 : A random value that uniquely identifies the challenge.  This value MUST have
-at least 128 bits of entropy, in order to prevent an attacker from guessing it.
+at least 128 bits of entropy in order to prevent fully automatic challenge response without knowing the token from challenge creation.
 It MUST NOT contain any characters outside the base64url alphabet, including
 padding characters ("=").
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2761,6 +2761,17 @@ server is in a default virtual host configuration.  Conversely, if the TLS
 server returns an unrecognized_name alert, then this is an indication that the
 server is not in a default virtual host configuration.
 
+## Token Entropy
+
+The http-01, tls-sni-02 and dns-01 validation methods mandate the usage of
+a random token value to uniquely identify the challenge. The value of the token
+is required to contain at least 182 bits of entropy for the following security
+properties. First, the ACME client should not be able to influence the ACME
+server's choice of token as this may allow an attacker to reuse a domain owner's
+previous challenge responses for a new validation request. Secondly, the entropy
+requirement prevents ACME clients from implementing a "naive" validation server
+that automatically replies to challenges without participating in the creation
+of the intial authorization request.
 
 # Acknowledgements
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1969,9 +1969,8 @@ type (required, string):
 
 token (required, string):
 : A random value that uniquely identifies the challenge.  This value MUST have
-at least 128 bits of entropy, in order to prevent an attacker from guessing it.
-It MUST NOT contain any characters outside the base64url alphabet, including
-padding characters ("=").
+at least 128 bits of entropy. It MUST NOT contain any characters outside the
+base64url alphabet, including padding characters ("=").
 
 ~~~~~~~~~~
 GET /acme/authz/1234/1 HTTP/1.1
@@ -2071,9 +2070,8 @@ type (required, string):
 
 token (required, string):
 : A random value that uniquely identifies the challenge.  This value MUST have
-at least 128 bits of entropy, in order to prevent an attacker from guessing it.
-It MUST NOT contain any characters outside the base64url alphabet, including
-padding characters ("=").
+at least 128 bits of entropy. It MUST NOT contain any characters outside the
+base64url alphabet, including padding characters ("=").
 
 ~~~~~~~~~~
 GET /acme/authz/1234/2 HTTP/1.1

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1867,7 +1867,7 @@ type (required, string):
 
 token (required, string):
 : A random value that uniquely identifies the challenge.  This value MUST have
-at least 128 bits of entropy in order to prevent fully automatic challenge response without knowing the token from challenge creation.
+at least 128 bits of entropy.
 It MUST NOT contain any characters outside the base64url alphabet, including
 padding characters ("=").
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2765,7 +2765,7 @@ server is not in a default virtual host configuration.
 
 The http-01, tls-sni-02 and dns-01 validation methods mandate the usage of
 a random token value to uniquely identify the challenge. The value of the token
-is required to contain at least 182 bits of entropy for the following security
+is required to contain at least 128 bits of entropy for the following security
 properties. First, the ACME client should not be able to influence the ACME
 server's choice of token as this may allow an attacker to reuse a domain owner's
 previous challenge responses for a new validation request. Secondly, the entropy


### PR DESCRIPTION
Per feedback from Zach Shepherd[0] on the mailing list the justification
for the 128 bits of required token entropy from section 8.2 is at odds
with the actual rationale (as I understand it).

This commit updates the justification for the entropy requirement to not
mention being secret from an attacker, but instead not predictable by
a naive challenge response server that would complete challenges
without having been a party to the authz/chal creation.