### PR TITLE
Additional editorial changes

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -360,25 +360,26 @@ provide an integrity mechanism, which protects against an intermediary
 changing the request URI to another ACME URI.
 
 As noted in {{request-authentication}} above, all ACME request objects carry a
-"url" parameter in their protected header.  This header parameter encodes the URL
-to which the client is directing the request.  On receiving such an object in an
-HTTP request, the server MUST compare the "url" parameter to the request URI.  If
-the two do not match, then the server MUST reject the request as unauthorized.
+"url" header parameter in their protected header.  This header parameter encodes
+the URL to which the client is directing the request.  On receiving such an
+object in an HTTP request, the server MUST compare the "url" header parameter to
+the request URI.  If the two do not match, then the server MUST reject the
+request as unauthorized.
 
 Except for the directory resource, all ACME resources are addressed with URLs
-provided to the client by the server.  For these resources, the client MUST set the
-"url" field to the exact string provided by the server (rather than performing
-any re-encoding on the URL).  The server SHOULD perform the corresponding string
-equality check, configuring each resource with the URL string provided to
-clients and having the resource check that requests have the same string in
-their "url" fields.
+provided to the client by the server.  For these resources, the client MUST set
+the "url" header parameter to the exact string provided by the server (rather
+than performing any re-encoding on the URL).  The server SHOULD perform the
+corresponding string equality check, configuring each resource with the URL
+string provided to clients and having the resource check that requests have the
+same string in their "url" header parameter.
 
 ### "url" (URL) JWS header parameter
 
-The "url" header parameter specifies the URL {{!RFC3986}} to which this JWS object is
-directed.  The "url" parameter MUST be carried in the protected
-header of the JWS.  The value of the "url" header MUST be a string representing
-the URL.
+The "url" header parameter specifies the URL {{!RFC3986}} to which this JWS
+object is directed.  The "url" header parameter MUST be carried in the protected
+header of the JWS.  The value of the "url" header parameter MUST be a string
+representing the URL.
 
 ## Replay protection
 
@@ -1142,9 +1143,9 @@ The outer JWS MUST meet the normal requirements for an ACME JWS (see
 {{request-authentication}}).  The inner JWS MUST meet the normal requirements,
 with the following exceptions:
 
-* The inner JWS MUST have the same "url" parameter as the outer JWS.
-* The inner JWS is NOT REQUIRED to have a "nonce" parameter.  The server MUST
-  ignore any value provided for the "nonce" header parameter.
+* The inner JWS MUST have the same "url" header parameter as the outer JWS.
+* The inner JWS is NOT REQUIRED to have a "nonce" header parameter.  The server
+  MUST ignore any value provided for the "nonce" header parameter.
 
 This transaction has signatures from both the old and new keys so that the
 server can verify that the holders of the two keys both agree to the change.

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -665,9 +665,9 @@ Account resources have the following structure:
 
 status (required, string):
 : The status of this account. Possible values are: "valid", "deactivated", and
-"revoked".  The value "deactivated" should be used to indicate user initiated
-deactivation whereas "revoked" should be used to indicate administratively
-initiated deactivation.
+"revoked".  The value "deactivated" should be used to indicate client-initiated
+deactivation whereas "revoked" should be used to indicate server-initiated
+deactivation.
 
 contact (optional, array of string):
 : An array of URIs that the server can use to contact the client for issues

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -829,8 +829,8 @@ absent, then the CA MUST consider this authorization valid for all orders until
 the authorization expires.
 
 challenges (required, array of objects):
-: The challenges that the client can fulfill in order to prove possession of the
-identifier (for pending authorizations).  For final authorizations, the
+: For pending authorizations, the challenges that the client can fulfill in
+order to prove possession of the identifier.  For final authorizations, the
 challenges that were used.  Each array entry is an object with parameters
 required to validate the challenge.  A client should attempt to fulfill
 one of these challenges, and a server should consider any one of the challenges

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -459,11 +459,11 @@ documentation about the specific hit rate limits using the
 
 ## Errors
 
-Errors can be reported in ACME both at the HTTP layer and within challenge objects
-as defined in {{identifier-validation-challenges}. ACME servers can return
-responses with an HTTP error response code (4XX or 5XX). For example:  If the
-client submits a request using a method not allowed in this document, then the
-server MAY return status code 405 (Method Not Allowed).
+Errors can be reported in ACME both at the HTTP layer and within challenge
+objects as defined in {{identifier-validation-challenges}}. ACME servers can
+return responses with an HTTP error response code (4XX or 5XX). For example:
+If the client submits a request using a method not allowed in this document,
+then the server MAY return status code 405 (Method Not Allowed).
 
 When the server responds with an error status, it SHOULD provide additional
 information using a problem document {{!RFC7807}}.  To facilitate automatic


### PR DESCRIPTION
This pull request includes changes to:

- Consistently use "header parameter" when referring to JWS header parameters.
- Insert a missing right curly bracket in a section reference.
- Use "server-initiated" instead of "administratively initiated" for clarity.
- Use parallel sentence structure for clarity/readability.