### PR TITLE
Clarify language relating to proactive certificate issuance

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1325,14 +1325,15 @@ client fails to complete the required actions before the "expires" time, then
 the server SHOULD change the status of the order to "invalid" and MAY
 delete the order resource.
 
-The server MUST issue the requested certificate and update the order resource
-with a URL for the certificate shortly after the client has fulfilled the server's
-requirements.   If the client has already satisfied the server's requirements at
-the time of this request (e.g., by obtaining authorization for all of the
-identifiers in the certificate in previous transactions), then the server MUST
-proactively issue the requested certificate and provide a URL for it in the
-"certificate" field of the order.  The server MUST, however, still list the
-completed authorizations in the "authorizations" array.
+The server MUST begin the issuance process for the requested certificate and
+update the order resource with a URL for the certificate once the client has
+fulfilled the server's requirements.   If the client has already satisfied the
+server's requirements at the time of this request (e.g., by obtaining
+authorization for all of the identifiers in the certificate in previous
+transactions), then the server MUST proactively issue the requested certificate
+and provide a URL for it in the "certificate" field of the order.  The server
+MUST, however, still list the completed authorizations in the "authorizations"
+array.
 
 Once the client believes it has fulfilled the server's requirements, it should
 send a GET request to the order resource to obtain its current state.  The


### PR DESCRIPTION
This change replaces "shortly" in the normative language of Section 7.4, Applying for Certificate Issuance, with the more precise expectation that the server begin the issuance process, as discussed on the mailing list.

https://mailarchive.ietf.org/arch/msg/acme/QzZf_jQq7cALDAkaS3T1yJ3XPMk