### PR TITLE
Adds "unsupportedContact" error, makes "mailto:" MTI.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -940,7 +940,7 @@ support an extension field.
 
 The server SHOULD validate that the contact URIs in the "contact" field are
 valid and supported by the server. If the server validates contact URIs it MUST
-support the mailto scheme. If the server rejects a contact URI for using an
+support the "mailto" scheme. If the server rejects a contact URI for using an
 unsupported scheme it MUST return an error of type "unsupportedContact", with
 a description describing the error and what types of contact URIs the server
 considers acceptable. If the server rejects a contact URI for using a supported

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -939,12 +939,13 @@ resulting account object.  This allows clients to detect when servers do not
 support an extension field.
 
 The server SHOULD validate that the contact URIs in the "contact" field are
-valid and supported by the server. If the client provides the server with
-a contact URI using an unsupported protocol it MUST return an error of type
-"unsupportedContact", with a description describing the error and what types of
-contact URIs the server considers acceptable. The server MUST support the mailto
-scheme for contact URIs. If the client provides the server with an invalid
-contact URI, then the server MUST return an error of type "invalidContact".
+valid and supported by the server. If the server validates contact URIs it MUST
+support the mailto scheme. If the server rejects a contact URI for using an
+unsupported scheme it MUST return an error of type "unsupportedContact", with
+a description describing the error and what types of contact URIs the server
+considers acceptable. If the server rejects a contact URI for using a supported
+scheme but an invalid value then the server MUST return an error of type
+"invalidContact".
 
 The server creates an account and stores the public key used to verify the
 JWS (i.e., the "jwk" element of the JWS header) to authenticate future requests

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -938,13 +938,13 @@ not recognize.  In particular, it MUST NOT reflect unrecognized fields in the
 resulting account object.  This allows clients to detect when servers do not
 support an extension field.
 
-The server SHOULD validate that the contact URLs in the "contact" field are
+The server SHOULD validate that the contact URIs in the "contact" field are
 valid and supported by the server. If the client provides the server with
-a contact URL using an unsupported protocol it MUST return an error of type
-"unsupportedContact". The server MUST support the "mailto:" protocol. If the
-client provides the server with an invalid contact URL, then the server MUST
-return an error of type "invalidContact", with a description describing the
-error and what types of contact URL the server considers acceptable.
+a contact URI using an unsupported protocol it MUST return an error of type
+"unsupportedContact", with a description describing the error and what types of
+contact URIs the server considers acceptable. The server MUST support the mailto
+scheme for contact URIs. If the client provides the server with an invalid
+contact URI, then the server MUST return an error of type "invalidContact".
 
 The server creates an account and stores the public key used to verify the
 JWS (i.e., the "jwk" element of the JWS header) to authenticate future requests

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -475,6 +475,7 @@ in the "type" field (within the "urn:ietf:params:acme:error:" namespace):
 | badNonce              | The client sent an unacceptable anti-replay nonce                              |
 | badSignatureAlgorithm | The JWS was signed with an algorithm the server does not support               |
 | invalidContact        | The contact URI for an account was invalid                                     |
+| unsupportedContact    | The contact URI for an account used an unsupported protocol scheme             |
 | malformed             | The request message was malformed                                              |
 | rateLimited           | The request exceeds a rate limit                                               |
 | rejectedIdentifier    | The server will not issue for the identifier                                   |
@@ -938,10 +939,12 @@ resulting account object.  This allows clients to detect when servers do not
 support an extension field.
 
 The server SHOULD validate that the contact URLs in the "contact" field are
-valid and supported by the server.  If the client provides the server with an
-invalid or unsupported contact URL, then the server MUST return an error of type
-"invalidContact", with a description describing the error and what types of
-contact URL the server considers acceptable.
+valid and supported by the server. If the client provides the server with
+a contact URL using an unsupported protocol it MUST return an error of type
+"unsupportedContact". The server MUST support the "mailto:" protocol. If the
+client provides the server with an invalid contact URL, then the server MUST
+return an error of type "invalidContact", with a description describing the
+error and what types of contact URL the server considers acceptable.
 
 The server creates an account and stores the public key used to verify the
 JWS (i.e., the "jwk" element of the JWS header) to authenticate future requests

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -474,8 +474,8 @@ in the "type" field (within the "urn:ietf:params:acme:error:" namespace):
 | badCSR                | The CSR is unacceptable (e.g., due to a short key)                             |
 | badNonce              | The client sent an unacceptable anti-replay nonce                              |
 | badSignatureAlgorithm | The JWS was signed with an algorithm the server does not support               |
-| invalidContact        | The contact URI for an account was invalid                                     |
-| unsupportedContact    | The contact URI for an account used an unsupported protocol scheme             |
+| invalidContact        | A contact URI for an account was invalid                                       |
+| unsupportedContact    | A contact URI for an account used an unsupported protocol scheme               |
 | malformed             | The request message was malformed                                              |
 | rateLimited           | The request exceeds a rate limit                                               |
 | rejectedIdentifier    | The server will not issue for the identifier                                   |


### PR DESCRIPTION
Firstly, this PR updates the table of errors in Section 6.6
"Errors" to add an "unsupportedContact" error type in addition to
"invalidContact". The former is returned when the contact URI protocol
is unsupported and the latter when the protocol is supported but the
provided contact is invalid.

Secondly, this PR updates Section 7.3 "Account Creation" to both
mention the new "unsupportedContact" error type and to make support of
the "mailto:" protocol a MUST.