### PR TITLE
Fixed Markdown formatting for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the working area for the Working Group internet-draft, "Automatic Certif
 
 * [Editor's copy](https://ietf-wg-acme.github.io/acme/)
 * [Build history](https://circleci.com/gh/ietf-wg-acme/acme)
-* [Working Group Draft] (https://tools.ietf.org/html/draft-ietf-acme-acme)
+* [Working Group Draft](https://tools.ietf.org/html/draft-ietf-acme-acme)
 
 
 ## Contributing


### PR DESCRIPTION
There shouldn't be a space between `]` and `(` in `[link](http://...)`.