### PR TITLE
Fix use of kid and jwk fields in examples

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1195,7 +1195,7 @@ Content-Type: application/jose+json
 {
   "protected": base64url({
     "alg": "ES256",
-    "jwk": /* old key */,
+    "kid": "https://example.com/acme/acct/1",
     "nonce": "K60BWPrMQG9SDxBDS_xtSw",
     "url": "https://example.com/acme/key-change"
   }),
@@ -1431,7 +1431,7 @@ Content-Type: application/jose+json
 {
   "protected": base64url({
     "alg": "ES256",
-    "jwk": {...},
+    "kid": "https://example.com/acme/acct/1",
     "nonce": "uQpSjlRb4vQVCjVYAyyUWg",
     "url": "https://example.com/acme/new-authz"
   }),
@@ -1741,7 +1741,7 @@ Content-Type: application/jose+json
 {
   "protected": base64url({
     "alg": "ES256",
-    "kid": "https://example.com/acme/acct/1", // OR "jwk"
+    "jwk": /* account key */,
     "nonce": "JHb54aT_KTXBWQOzGYkt9A",
     "url": "https://example.com/acme/revoke-cert"
   }),


### PR DESCRIPTION
This pull request relates to issue #310. It assumes that the description about the usage of the "kid" and "jwk" fields in the "Request Authentication" section is correct, and only the example JSONs need to be fixed.