### PR TITLE
Remove "type" field in challenge response example

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1625,7 +1625,6 @@ Content-Type: application/jose+json
     "url": "https://example.com/acme/authz/1234/0"
   }),
   "payload": base64url({
-    "type": "http-01",
     "keyAuthorization": "IlirfxKKXA...vb29HhjjLPSggwiE"
   }),
   "signature": "9cbg5JO1Gf5YLjjz...SpkUfcdPai9uVYYQ"


### PR DESCRIPTION
As pointed out on the list, this was inconsistent with the sections that define
challenge responses, which show a challenge POST with no "type" field in the
payload.