### PR TITLE
Clarification of integrity of authorizations in the threat model

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2623,9 +2623,10 @@ account key for one of his choosing, e.g.:
   account key A (the legitimate domain holder)
 
 All of the challenges above have a binding between the account private key and
-the validation query made by the server, via the key authorization.  The key
-authorization is signed by the account private key, reflects the corresponding
-public key, and is provided to the server in the validation response.
+the validation query made by the server, via the key authorization. The key
+authorization reflects the account public key, is provided to the server in the
+validation response over the validation channel and signed afterwards by the
+corresponding private key in the challenge response over the ACME channel.
 
 The association of challenges to identifiers is typically done by requiring the
 client to perform some action that only someone who effectively controls the


### PR DESCRIPTION
As pointed out to the list:

There is this sentence in the security considerations (10.2 Integrity of Authorizations) that strikes me as extremely misleading:

"All of the challenges above have a binding between the account private key and the validation query made by the server, via the key authorization.  The key authorization is signed by the account private key, reflects the corresponding public key, and is provided to the server in the validation response."

The key authorization itself does NOT contain the signature of the account's key. It gets though signed by the account's key later on in the challenge response (not the validation response) over the ACME channel (not the validation channel). What about saying that in the chronological order of events?