### PR TITLE
Provide `Location` header on key-change conflict.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1244,7 +1244,8 @@ If all of these checks pass, then the server updates the corresponding account
 by replacing the old account key with the new public key and returns status
 code 200 (OK). Otherwise, the server responds with an error status code and a
 problem document describing the error.  If there is an existing account with
-the new key provided, then the server SHOULD use status code 409 (Conflict).
+the new key provided, then the server SHOULD use status code 409 (Conflict) and
+provide the URL of that account in the Location header field.
 
 Note that changing the account key for an account SHOULD NOT have any other
 impact on the account.  For example, the server MUST NOT invalidate pending


### PR DESCRIPTION
Similar to Section 7.3.1 "Finding an Account URL Given a Key" when a key
rollover request will result in a conflict with an existing account the
`Location` header of the response should indicate the URL of the
conflicting account. This saves the client from having to post the
new-account endpoint to learn the account URL.