### PR TITLE
Remove proactive issuance & csr-first new-order.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -803,8 +803,11 @@ certificate (optional, string):
 }
 ~~~~~~~~~~
 
-Identifiers in a new-order request MAY contain wildcard identifiers, even if
-the resulting authorizations returned by the server do not.
+Identifiers in a new-order request MAY contain DNS type identifiers with
+wildcard values, even if the resulting authorizations returned by the server do
+not. DNS type identifiers for a wildcard value MUST contain only one '*'
+wildcard character comprising the entire leftmost DNS label. (E.g.
+"*.foo.example.com" not "foo.*.example.com" or "*.*.example.com").
 
 The elements of the "authorizations" and "identifiers" array are immutable once
 set.  The server MUST NOT change the contents either array after they are

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -784,7 +784,11 @@ certificate (optional, string):
   "status": "valid",
   "expires": "2015-03-01T14:09:00Z",
 
-  "csr": "jcRf4uXra7FGYW5ZMewvV...rhlnznwy8YbpMGqwidEXfE",
+  "identifiers": [
+    { "type": "dns", "value": "example.com" },
+    { "type": "dns", "value": "www.example.com" }
+  ],
+
   "notBefore": "2016-01-01T00:00:00Z",
   "notAfter": "2016-01-08T00:00:00Z",
 
@@ -792,6 +796,8 @@ certificate (optional, string):
     "https://example.com/acme/authz/1234",
     "https://example.com/acme/authz/2345"
   ],
+
+  "finalizeURL": "https://example.com/acme/acct/1/order/1/finalize",
 
   "certificate": "https://example.com/acme/cert/1234"
 }

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1372,7 +1372,7 @@ Location: https://example.com/acme/order/asdf
     "https://example.com/acme/authz/2345"
   ],
 
-  "finalizeURL": "https://example.com/acme/order/finalize/asdf"
+  "finalizeURL": "https://example.com/acme/order/asdf/finalize"
 }
 ~~~~~~~~~~
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -772,8 +772,8 @@ with a GET request.
 
 finalizeURL (requred, string):
 : A URL that a CSR must be POSTed to once all of the order's authorizations are
-satisfied in order to finalize the order. The result of a successful
-finalization will be the population of the certificate URL for the order.
+satisfied to finalize the order. The result of a successful finalization will be
+the population of the certificate URL for the order.
 
 certificate (optional, string):
 : A URL for the certificate that has been issued in response to this order.

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -803,11 +803,13 @@ certificate (optional, string):
 }
 ~~~~~~~~~~
 
-Identifiers in a new-order request MAY contain DNS type identifiers with
-wildcard values, even if the resulting authorizations returned by the server do
-not. DNS type identifiers for a wildcard value MUST contain only one '*'
-wildcard character comprising the entire leftmost DNS label. (E.g.
-"*.foo.example.com" not "foo.*.example.com" or "*.*.example.com").
+Any identifier of type "dns" in a new-order request MAY have a wildcard domain
+name as its value. A wildcard domain name consists of a single asterisk
+character followed by a single full stop character ("*.") followed by a domain
+name as defined for use in the Subject Alternate Name Extension by RFC 5280
+{{!RFC5280}}. An authorization returned by the server for a wildcard domain name
+identifier MUST NOT include the asterisk and full stop ("*.") prefix in the
+authorization identifier value.
 
 The elements of the "authorizations" and "identifiers" array are immutable once
 set.  The server MUST NOT change the contents either array after they are


### PR DESCRIPTION
This commit implements a first go at the replacement of proactive issuance
and the "CSR first" new-order flow [proposed on the ACME mailing list](https://mailarchive.ietf.org/arch/msg/acme/DIjJEB06J5cFyuOlGPVcY2I51vg)

Mentions of proactive issuance are removed. The CSR field of the order
object is removed. A new "finalizeURL" field is added to the order
object. A new "identifiers" field is added to the order object. Issuance
process is updated to describe submitting identifiers in the new-order
request and POSTing a CSR to the order's finalizeURL.
