### PR TITLE
Leading slash for Well-Known URI

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1963,12 +1963,12 @@ client then provisions the key authorization as a resource on the HTTP server
 for the domain in question.
 
 The path at which the resource is provisioned is comprised of the fixed prefix
-".well-known/acme-challenge/", followed by the "token" value in the challenge.
+"/.well-known/acme-challenge/", followed by the "token" value in the challenge.
 The value of the resource MUST be the ASCII representation of the key
 authorization.
 
 ~~~~~~~~~~
-GET .well-known/acme-challenge/LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0
+GET /.well-known/acme-challenge/LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0
 Host: example.org
 
 HTTP/1.1 200 OK


### PR DESCRIPTION
The URL pathname should start with a `/` slash.

https://tools.ietf.org/html/rfc5785#section-3

> 3.  Well-Known URIs
> 
>    A well-known URI is a URI [RFC3986] whose path component begins with
>    the characters "/.well-known/", and whose scheme is "HTTP", "HTTPS",
>    or another scheme that has explicitly been specified to use well-
>    known URIs.
> 
>    Applications that wish to mint new well-known URIs MUST register
>    them, following the procedures in Section 5.1.
> 
>    For example, if an application registers the name 'example', the
>    corresponding well-known URI on 'http://www.example.com/' would be
>    'http://www.example.com/.well-known/example'.

https://tools.ietf.org/html/rfc5785#section-5.1.1

> 5.1.1.  Registration Template
> 
>    URI suffix:  The name requested for the well-known URI, relative to
>       "/.well-known/"; e.g., "example".
