### PR TITLE
Remove obsolete mention of authz reuse in pre-auth flow.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1532,8 +1532,7 @@ URL for the new authorization resource.
 
 To request authorization for an identifier, the client sends a POST request to
 the new-authorization resource specifying the identifier for which authorization
-is being requested and how the server should behave with respect to existing
-authorizations for this identifier.
+is being requested.
 
 identifier (required, object):
 : The identifier that the account is authorized to represent:


### PR DESCRIPTION
Previously there was some notion of being able to hint to the server
whether you wanted to reuse authorizations. This was removed from the
spec but the pre-authorization flow still made a reference to it. This
commit removes that obsolete reference. Thanks to @andriymahats for
pointing out the error.

Resolves https://github.com/ietf-wg-acme/acme/issues/364