### PR TITLE
Ignore `.targets.mk`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 venv/
 draft-ietf-acme-acme.xml
 lib
+.targets.mk


### PR DESCRIPTION
Running the included Makefile can produce a `.targets.mk` artifact in
the working directory that isn't suitable for committing to the repo but
also wasn't in the `.gitignore`. This commit adds it to the list of
ignored files.