### PR TITLE
Clarify "newAuthz" directory endpoint is optional.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -700,7 +700,7 @@ should not clash with other services. For instance:
    under the path "/".
 
 If the ACME server does not implement pre-authorization (Section 7.4.1) it
-SHOULD omit the "newAuthz" field of the directory.
+MUST omit the "newAuthz" field of the directory.
 
 The object MAY additionally contain a field "meta". If present, it MUST be a
 JSON object; each field in the object is an item of metadata relating to

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -699,8 +699,8 @@ should not clash with other services. For instance:
  * a host which only functions as an ACME server could place the directory
    under the path "/".
 
-If the ACME server does not implement pre-authorization (Section 7.4.1) it MAY
-omit the "newAuthz" field of the directory.
+If the ACME server does not implement pre-authorization (Section 7.4.1) it
+SHOULD omit the "newAuthz" field of the directory.
 
 The object MAY additionally contain a field "meta". If present, it MUST be a
 JSON object; each field in the object is an item of metadata relating to

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -699,6 +699,9 @@ should not clash with other services. For instance:
  * a host which only functions as an ACME server could place the directory
    under the path "/".
 
+If the ACME server does not implement pre-authorization (Section 7.4.1) it MAY
+omit the "newAuthz" field of the directory.
+
 The object MAY additionally contain a field "meta". If present, it MUST be a
 JSON object; each field in the object is an item of metadata relating to
 the service provided by the ACME server.


### PR DESCRIPTION
In Section 7.4.1 "Pre-Authorization" the spec says:

     If a CA wishes to allow pre-authorization within ACME, it can offer
     a "new authorization" resource in its directory by adding the field
     "newAuthz" with a URL for the new authorization resource.

That text indicates that the CA may wish to *not* support
pre-authorization in which case the "newAuthz" resource will not be
present in the directory. One example of an ACME CA choosing to 
not support pre-authorization is Let's Encrypt.

This commit clarifies the "newAuthz" field of the directory is optional 
in Section 7.1.1 "Directory" where a developer is likely to look to 
understand which resources must be supported/present in the directory
and which are optional ("meta", "newAuthz"). If the server doesn't support
pre-authorization it MUST omit the "newAuthz" field.
  
  