### PR TITLE
Don't use reasonCode=0 in OCSP/CRLs

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1915,7 +1915,7 @@ it is different from PEM.)
 reason (optional, int):
 : One of the revocation reasonCodes defined in Section 5.3.1 of {{RFC5280}}
 to be used when generating OCSP responses and CRLs. If this field is not set
-the server SHOULD use the unspecified (0) reasonCode value when generating OCSP
+the server SHOULD omit the reason code CRL entry extension when generating OCSP
 responses and CRLs. The server MAY disallow a subset of reasonCodes from being
 used by the user. If a request contains a disallowed reasonCode the server MUST
 reject it with the error type "urn:ietf:params:acme:error:badRevocationReason".

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1929,7 +1929,7 @@ it is different from PEM.)
 reason (optional, int):
 : One of the revocation reasonCodes defined in Section 5.3.1 of {{RFC5280}}
 to be used when generating OCSP responses and CRLs. If this field is not set
-the server SHOULD omit the reason code CRL entry extension when generating OCSP
+the server SHOULD omit the reasonCode CRL entry extension when generating OCSP
 responses and CRLs. The server MAY disallow a subset of reasonCodes from being
 used by the user. If a request contains a disallowed reasonCode the server MUST
 reject it with the error type "urn:ietf:params:acme:error:badRevocationReason".


### PR DESCRIPTION
As recommended by [RFC 5280](https://tools.ietf.org/html/rfc5280#section-5.3.1).  Thanks to [Jörn Heissler](https://mailarchive.ietf.org/arch/msg/acme/BD9QPnRD5IiUbHpBDM54i2FMC6Q) for the catch.