### PR TITLE
Clarify account URL == kid in account creation section.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1084,7 +1084,9 @@ agreement to terms.
 The server creates an account and stores the public key used to verify the
 JWS (i.e., the "jwk" element of the JWS header) to authenticate future requests
 from the account.  The server returns this account object in a 201 (Created)
-response, with the account URL in a Location header field.
+response, with the account URL in a Location header field. The account URL is
+used as the "kid" value in the JWS authenticating subsequent requests by this
+account (See {{request-authentication}}).
 
 ~~~~~~~~~~
 HTTP/1.1 201 Created


### PR DESCRIPTION
Section 6.2 "Request Authentication" says:
> For all other requests, there MUST be a "kid" field.  This field
> must contain the account URL received by POSTing to the new-account
> resource.

Prior to this commit Section 7.3 "Account Creation" doesn't mention that
the account URL also doubles as the key ID. To make the question of
"What is my Key ID?" more obvious for client implementers this commit
adds a brief mention of this fact where the specification discusses the
account URL.

Thanks to @unixcharles for flagging this and providing a chance to avoid
confusion and add clarity.