### PR TITLE
Use Content-Type to indicate JWS serialization format

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -337,6 +337,7 @@ authentication of requests.
 JWS objects sent in ACME requests MUST meet the following additional criteria:
 
 * The JWS MUST NOT have the value "none" in its "alg" field
+* The JWS MUST NOT have multiple signatures. 
 * The JWS MUST NOT have a Message Authentication Code (MAC)-based algorithm in its "alg" field
 * The JWS Protected Header MUST include the following fields:
   * "alg" (Algorithm)
@@ -365,7 +366,27 @@ and type "urn:ietf:params:acme:error:badSignatureAlgorithm".  The problem
 document returned with the error MUST include an "algorithms" field with an
 array of supported "alg" values.
 
-In the examples below, JWS objects are shown in the JSON or flattened JSON
+## JWS Serialization Formats
+
+The JSON Web Signature (JWS) specification {{!RFC7515}} contains 
+three different serialization formats. When sending JWS payloads, 
+ACME client and server implementations MUST 
+use the HTTP Content-Type {{!RFC7231}} header 
+to indicate what JWS serialization format is used. 
+The following Content-Type values may be used for this purpose:
+
+ - "application/jose":
+   - The JWS Compact Serialization {{!RFC7515}} MUST be used. 
+   - The JWS Payload MUST NOT be detached. 
+   - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used. 
+ - "application/jose+json":
+   - Either the JWS Flattened JSON {{!RFC7515}} 
+     or the JWS General JSON {{!RFC7515}} Serialization MUST be used. 
+   - The JWS Payload MUST NOT be detached. 
+   - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used.
+   - The JWS Unprotected Header {{!RFC7515}} SHOULD NOT be used. 
+
+In the examples below, JWS objects are shown in the General JSON or Flattened JSON
 serialization, with the protected header and payload expressed as
 base64url(content) instead of the actual base64-encoded value, so that the content
 is readable.

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -369,10 +369,10 @@ array of supported "alg" values.
 ## JWS Serialization Formats
 
 The JSON Web Signature (JWS) specification {{!RFC7515}} contains 
-three different serialization formats. When sending JWS payloads, 
-ACME client and server implementations MUST 
-use the HTTP Content-Type {{!RFC7231}} header 
-to indicate what JWS serialization format is used. 
+multiple JWS serialization formats. When sending an ACME request 
+with a non-empty body, an ACME client implementation MUST use the 
+HTTP Content-Type {{!RFC7231}} header to indicate which JWS serialization format 
+is used for encapsulating the ACME request payload.
 The following Content-Type values may be used for this purpose:
 
  - "application/jose":
@@ -380,8 +380,8 @@ The following Content-Type values may be used for this purpose:
    - The JWS Payload MUST NOT be detached. 
    - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used. 
  - "application/jose+json":
-   - Either the JWS Flattened JSON {{!RFC7515}} 
-     or the JWS General JSON {{!RFC7515}} Serialization MUST be used. 
+   - Either the JWS Flattened JSON Serialization {{!RFC7515}} 
+     or the JWS General JSON Serialization {{!RFC7515}} MUST be used. 
    - The JWS Payload MUST NOT be detached. 
    - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used.
    - The JWS Unprotected Header {{!RFC7515}} SHOULD NOT be used. 


### PR DESCRIPTION
# Introduction

This change is designed to partially address the JWS serialization format issues raised in the [Specify which JWS serialization is used](https://www.ietf.org/mail-archive/web/acme/current/msg02417.html) and [JWS serialization](https://www.ietf.org/mail-archive/web/acme/current/msg01690.html) threads on the mailing list. 

This change uses the Content-Type header to specify JWS serialization formats, and includes restrictions on the serializations. It doesn't include converting between serializations, or how to handle inner JWS messages.  

In short, this change should be a cleaner version of #382 that still allows the compact serialization. 

# What the Pull Request Includes

Specifically, this change requires ACME implementations to use the HTTP Content-Type header to indicate the JWS serialization format used for the request body. The change also specifies restrictions on the specific serialization formats when used with ACME (don't use unencoded payloads, don't use detached payloads, don't use unprotected headers). In addition, the change prohibits multiple signatures in JWS objects used for ACME purposes. 

# What the Pull Request Doesn't Include

## Converting between JWS Serializations

This change doesn't include advice on how to convert between the JWS serializations. Converting between JWS serializations may be needed if, for example, an ACME implementation uses a JWS library that doesn't support all JWS serializations and/or doesn't provide programmers with control over what JWS serialization is produced. In such cases, programmers may have to convert between JWS serializations before and/or after using said pre-existing JWS library. 

I have started a draft of a separate JOSE serialization conversion guide at https://github.com/uhhhh2/jwe-jws-serialization-conversion-guide. The separate conversion guide is designed to not be ACME-specific. Accordingly, the separate conversion guide includes things like unencoded payloads, detached payloads, unprotected headers, and JWEs. 

## Applying the Serialization Requirements to A Nested JWS 

One thing that is not included in this change is how the serialization format requirements should be applied to a "nested" JWS like the one found in a key change or an external account binding. Should a "nested" JWS be required to use the same serialization as the "outer" JWS? 

If a nested JWS should follow the outer JWS serialization format, the following additional changes may need to be made:
 1. Change the new "JWS Serialization Formats" section (introduced in this pull request). For example, the list in that section could be changed to the following: 
    - Content-Type "application/jose":
      - A JWS of this Content-Type MUST meet the following criteria:
        - The JWS Compact Serialization {{!RFC7515}} MUST be used. 
        - The JWS Payload MUST NOT be detached. 
        - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used. 
      - A JWS placed anywhere inside the payload of a JWS of this Content-Type MUST meet the above criteria as well. 
    - Content-Type "application/jose+json":
      - A JWS of this Content-Type MUST meet the following criteria:
         - Either the JWS Flattened JSON {{!RFC7515}} or the JWS General JSON {{!RFC7515}} Serialization MUST be used. 
         - The JWS Payload MUST NOT be detached. 
         - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used.
         - The JWS Unprotected Header {{!RFC7515}} SHOULD NOT be used. 
      - A JWS placed anywhere inside the payload of a JWS of this Content-Type MUST meet the above criteria as well. 
 2. Update the specifications for the nested JWS: 
     - Right now, "externalAccountBinding" can be an object. If this JWS must follow the same guidelines as the outer JWS, "externalAccountBinding" could be an "object or string", depending on whether a JSON or compact serialization is used. 
    - If I understand correctly, the payload of the outer JWS for the "keyChange" (Account Key Roll-Over) endpoint is not a JSON object like in the other ACME requests. Instead, the payload for the "outer" JWS for this endpoint is merely this nested JWS itself. If this understanding is correct, I don't think any changes have to be made. If this understanding is not correct, I am not sure what changes may have to be made. 