### PR TITLE
Status Clarifications

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -843,8 +843,8 @@ the server requires the client to complete, and any certificates that have
 resulted from this order.
 
 status (required, string):
-: The status of this order.  Possible values are: "pending", "processing",
-"valid", and "invalid".
+: The status of this order.  Possible values are: "pending",
+"ready", "processing", "valid", and "invalid".
 
 expires (optional, string):
 : The timestamp after which the server will consider this order invalid, encoded
@@ -951,8 +951,8 @@ identifier (required, object):
   : The identifier itself.
 
 status (required, string):
-: The status of this authorization.  Possible values are: "pending", "processing",
-"valid", "invalid" and "revoked".
+: The status of this authorization.  Possible values are: "pending",
+"valid", "invalid", "deactivated", and "revoked".
 
 expires (optional, string):
 : The timestamp after which the server will consider this authorization invalid,
@@ -1036,7 +1036,7 @@ the challenges listed in the authorization transitions to the
 state.  If there is an error while the authorization is still
 pending (e.g., the authorization times out), then the authorizatoin
 transitions to the "invalid" state.  Once the authorization is in
-the valid state, it can expire ("expired"), be deactivated by the
+the valid state, it can expire ("invalid"), be deactivated by the
 client ("deactivated", see {{deactivating-an-authorization}}),
 revoked by the server ("revoked").
 
@@ -1047,16 +1047,18 @@ Error        |  Challenge -> valid
    +---------+---------+
    |                   |
    V                   V
-invalid              valid
-                       |
+invalid <----------- valid
+            Time       |
+           after       |
+         "expires"     |
                        |
            +-----------+-----------+
-           |           |           |
-     Time  |           |           |
-    after  |    Client |    Server |
- "expires" |   deactiv.|    revoke |
-           V           V           V
-        expired   deactivated   revoked
+           |                       |
+           |                       |
+    Client |                Server |
+   deactiv.|                revoke |
+           V                       V
+      deactivated               revoked
 ~~~~~~~~~~
 
 Order objects are created in the "pending" state.  Once all of the
@@ -2165,8 +2167,8 @@ url (required, string):
 : The URL to which a response can be posted.
 
 status (required, string):
-: The status of this challenge.  Possible values are: "pending", "valid",
-and "invalid".
+: The status of this challenge.  Possible values are: "pending",
+"processing", "valid", and "invalid".
 
 validated (optional, string):
 : The time at which the server validated this challenge, encoded in the

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1705,12 +1705,16 @@ action the client should take:
   requirements.  Check the "authorizations" array for entries that are still
   pending.
 
-* "processing": The server agrees that the requirements have been fulfilled, and
-  is in the process of generating the certificate.  Retry after the time given
-  in the "Retry-After" header field of the response, if any.
+* "ready": The server agrees that the requirements have been
+  fulfilled, and is awaiting on finalization.  Submit a finalization
+  request.
+
+* "processing": The certificate is being issued.  Retry after the
+  time given in the "Retry-After" header field of the response, if
+  any.
 
 * "valid": The server has issued the certificate and provisioned its URL to the
-  "certificate" field of the order.
+  "certificate" field of the order.  Download the certificate.
 
 ~~~~~~~~~~
 HTTP/1.1 200 OK

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1037,7 +1037,7 @@ state.
 
 ~~~~~~~~~~
          pending
-            | 
+            |
             | Receive
             | response
             V
@@ -1059,31 +1059,31 @@ Authorization objects are created in the "pending" state.  If one of
 the challenges listed in the authorization transitions to the
 "valid" state, then the authorization also changes to the "valid"
 state.  If there is an error while the authorization is still
-pending, then the authorizatoin transitions to the "invalid" state.
+pending, then the authorization transitions to the "invalid" state.
 Once the authorization is in the valid state, it can expire
-("invalid"), be deactivated by the client ("deactivated", see
+("expired"), be deactivated by the client ("deactivated", see
 {{deactivating-an-authorization}}), or revoked by the server
 ("revoked").
 
 ~~~~~~~~~~
-          pending
-             |
-Error        |  Challenge -> valid
-   +---------+---------+
-   |                   |
-   V                   V
-invalid <----------- valid
-            Time       |
-           after       |
-         "expires"     |
-                       |
-           +-----------+-----------+
-           |                       |
-           |                       |
-    Server |                Client |
-    revoke |            deactivate |
-           V                       V
-        revoked               deactivated
+          pending --------------------+
+             |                        |
+             |                        |
+ Error       |  Challenge valid       |
+   +---------+---------+              |
+   |                   |              |
+   V                   V              |
+invalid              valid            |
+                       |              |
+                       |              |
+                       |              |
+        +--------------+--------------+
+        |              |              |
+        |              |              |
+ Server |       Client |   Time after |
+ revoke |   deactivate |    "expires" |
+        V              V              V
+     revoked      deactivated      expired
 ~~~~~~~~~~
 
 Order objects are created in the "pending" state.  Once all of the
@@ -1095,7 +1095,7 @@ certificate.  Once the certificate is issued, the order enters the
 "valid" state.  If an error occurs at any of these stages, the
 order moves to the "invalid" state.  The order also moves to the
 "invalid" state if it expires, or one of its authorizations enters a
-final state other than "valid" ("invalid", "revoked", "deactivated")
+final state other than "valid" ("expired", "revoked", "deactivated").
 
 ~~~~~~~~~~
  pending --------------+
@@ -1110,8 +1110,8 @@ final state other than "valid" ("invalid", "revoked", "deactivated")
     | request          |
     V                  |
 processing ------------+
-    |                  | Fatal error or
-    | Certificate      | Expiration or
+    |                  |
+    | Certificate      | Error or
     | issued           | Authorization failure
     V                  V
   valid             invalid
@@ -1120,7 +1120,7 @@ processing ------------+
 Account objects are created in the "valid" state, since no further
 action is required to create an account after a successful
 newAccount request.  If the account is deactivated by the client  or
-revoked by the server, it moves to the corresponding state. 
+revoked by the server, it moves to the corresponding state.
 
 ~~~~~~~~~~
                   valid

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1010,6 +1010,9 @@ Challenge objects are created in the "pending" state.  They
 transition to the "processing" state when the client responds to the
 challenge (see {{responding-to-challenges}}) and the server begins
 attempting to validate that the client has completed the challenge.
+Note that within the "processing" state, the server may attempt to
+validate the challenge multiple times (see {{retrying-challenges}}).
+Likewise, client requests for retries do not cause a state change.
 If validation is successful, the challenge moves to the "valid"
 state; if there is an error, the challenge moves to the "invalid"
 state.
@@ -1020,7 +1023,11 @@ state.
             | Receive
             | response
             V
-        processing
+        processing <-+
+            |   |    | Server retry or
+            |   |    | client retry request
+            |   +----+
+            |
             |
 Successful  |   Failed
 validation  |   validation
@@ -2232,7 +2239,7 @@ scenarios that the schedule is trying to accommodate.  Given that retries are
 intended to address things like propagation delays in HTTP or DNS provisioning,
 there should not usually be any reason to retry more often than every 5 or 10
 seconds. While the server is still trying, the
-status of the challenge remains "pending"; it is only marked "invalid" once the
+status of the challenge remains "processing"; it is only marked "invalid" once the
 server has given up.
 
 The server MUST provide information about its retry state to the client via the

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1133,6 +1133,12 @@ deactiv.|                revoke |
    deactivated               revoked
 ~~~~~~~~~~
 
+Note that some of these states may not ever appear in a "status"
+field, depending on server behavior.  For example, a server that
+issues synchronously will never show an order in the "processing"
+state.  A server that deletes expired authorizations immediately
+will never show an authorization in the "expired" state.
+
 
 ## Getting a Nonce
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1041,11 +1041,11 @@ Authorization objects are created in the "pending" state.  If one of
 the challenges listed in the authorization transitions to the
 "valid" state, then the authorization also changes to the "valid"
 state.  If there is an error while the authorization is still
-pending (e.g., the authorization times out), then the authorizatoin
-transitions to the "invalid" state.  Once the authorization is in
-the valid state, it can expire ("invalid"), be deactivated by the
-client ("deactivated", see {{deactivating-an-authorization}}),
-revoked by the server ("revoked").
+pending, then the authorizatoin transitions to the "invalid" state.
+Once the authorization is in the valid state, it can expire
+("invalid"), be deactivated by the client ("deactivated", see
+{{deactivating-an-authorization}}), or revoked by the server
+("revoked").
 
 ~~~~~~~~~~
           pending
@@ -1062,10 +1062,10 @@ invalid <----------- valid
            +-----------+-----------+
            |                       |
            |                       |
-    Client |                Server |
-   deactiv.|                revoke |
+    Server |                Client |
+    revoke |            deactivate |
            V                       V
-      deactivated               revoked
+        revoked               deactivated
 ~~~~~~~~~~
 
 Order objects are created in the "pending" state.  Once all of the
@@ -1074,8 +1074,10 @@ the order transitions to the "ready" state.  The order moves to the
 "processing" state after the client submits a request to the order's
 "finalize" URL and the CA begins the issuance process for the
 certificate.  Once the certificate is issued, the order enters the
-"valid" state.  If a fatal error occurs at any of these stages, the
-order moves to the "invalid" state.
+"valid" state.  If an error occurs at any of these stages, the
+order moves to the "invalid" state.  The order also moves to the
+"invalid" state if it expires, or one of its authorizations enters a
+final state other than "valid" ("invalid", "revoked", "deactivated")
 
 ~~~~~~~~~~
  pending --------------+
@@ -1090,9 +1092,9 @@ order moves to the "invalid" state.
     | request          |
     V                  |
 processing ------------+
-    |                  |
-    | Certificate      | Fatal
-    | issued           | error
+    |                  | Fatal error or
+    | Certificate      | Expiration or
+    | issued           | Authorization failure
     V                  V
   valid             invalid
 ~~~~~~~~~~

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1706,10 +1706,10 @@ action the client should take:
   pending.
 
 * "ready": The server agrees that the requirements have been
-  fulfilled, and is awaiting on finalization.  Submit a finalization
+  fulfilled, and is awaiting finalization.  Submit a finalization
   request.
 
-* "processing": The certificate is being issued.  Retry after the
+* "processing": The certificate is being issued. Send a GET request after the
   time given in the "Retry-After" header field of the response, if
   any.
 


### PR DESCRIPTION
This PR attempts to add a lot more clarity to the "status" field on objects and how it evolves.

* Adds a section describing the state transitions for the various object types. (This turns out to be a handy protocol summary as well)
* Aligns the valid values in the "status" field definitions to the description in that section
* Adds a "ready" state on orders to indicate when the order is ready to be finalized

Fixes #391
Fixes #397 (by showing why challenges need separate status)

Slightly beyond the scope of this PR, it might also be good to:
* Define an "expired" status for autz, independent of "invalid"
* Add a subsection of "Applying for Certificate Issuance" briefly noting / illustrating finalization 
