### PR TITLE
Clarify serialization requirements for root and nested JWS messages

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -337,6 +337,7 @@ authentication of requests.
 JWS objects sent in ACME requests MUST meet the following additional criteria:
 
 * The JWS MUST NOT have the value "none" in its "alg" field
+* The JWS MUST NOT have multiple signatures. 
 * The JWS MUST NOT have a Message Authentication Code (MAC)-based algorithm in its "alg" field
 * The JWS Protected Header MUST include the following fields:
   * "alg" (Algorithm)
@@ -365,7 +366,27 @@ and type "urn:ietf:params:acme:error:badSignatureAlgorithm".  The problem
 document returned with the error MUST include an "algorithms" field with an
 array of supported "alg" values.
 
-In the examples below, JWS objects are shown in the JSON or flattened JSON
+## JWS Serialization Formats
+
+The JSON Web Signature (JWS) specification {{!RFC7515}} contains 
+three different serialization formats. When sending JWS payloads, 
+ACME client and server implementations MUST 
+use the HTTP Content-Type {{!RFC7231}} header 
+to indicate what JWS serialization format is used. 
+The following Content-Type values may be used for this purpose:
+
+ - "application/jose":
+   - The JWS Compact Serialization {{!RFC7515}} MUST be used. 
+   - The JWS Payload MUST NOT be detached. 
+   - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used. 
+ - "application/jose+json":
+   - Either the JWS Flattened JSON {{!RFC7515}} 
+     or the JWS General JSON {{!RFC7515}} Serialization MUST be used. 
+   - The JWS Payload MUST NOT be detached. 
+   - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used.
+   - The JWS Unprotected Header {{!RFC7515}} SHOULD NOT be used. 
+
+In the examples below, JWS objects are shown in the General JSON or Flattened JSON
 serialization, with the protected header and payload expressed as
 base64url(content) instead of the actual base64-encoded value, so that the content
 is readable.

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -369,10 +369,10 @@ array of supported "alg" values.
 ## JWS Serialization Formats
 
 The JSON Web Signature (JWS) specification {{!RFC7515}} contains 
-three different serialization formats. When sending JWS payloads, 
-ACME client and server implementations MUST 
-use the HTTP Content-Type {{!RFC7231}} header 
-to indicate what JWS serialization format is used. 
+multiple JWS serialization formats. When sending an ACME request 
+with a non-empty body, an ACME client implementation MUST use the 
+HTTP Content-Type {{!RFC7231}} header to indicate which JWS serialization format 
+is used for encapsulating the ACME request payload.
 The following Content-Type values may be used for this purpose:
 
  - "application/jose":
@@ -380,8 +380,8 @@ The following Content-Type values may be used for this purpose:
    - The JWS Payload MUST NOT be detached. 
    - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used. 
  - "application/jose+json":
-   - Either the JWS Flattened JSON {{!RFC7515}} 
-     or the JWS General JSON {{!RFC7515}} Serialization MUST be used. 
+   - Either the JWS Flattened JSON Serialization {{!RFC7515}} 
+     or the JWS General JSON Serialization {{!RFC7515}} MUST be used. 
    - The JWS Payload MUST NOT be detached. 
    - The JWS Unencoded Payload Option {{!RFC7797}} MUST NOT be used.
    - The JWS Unprotected Header {{!RFC7515}} SHOULD NOT be used. 


### PR DESCRIPTION
# What is Included
- An error code to deal with JWS serialization failures (copied from https://github.com/ietf-wg-acme/acme/pull/398) 
- A definition of a "root JWS" (a JWS encapsulating an entire ACME request payload) 
- A definition of a "nested JWS" (a JWS included within an ACME request payload)
- A modified "application/jose" JWS serialization Content-Type (to include specifications for both root and nested JWS instances)
- A modified "application/jose+json" JWS serialization Content-Type (to include specifications for both root and nested JWS instances)
- A "nested JWS" field type option in the existing ACME registries (to denote a nested JWS whose actual JSON type depends on the requirements of the JWS serialization Content-Type)
- A new ACME registry for the JWS serialization Content-Types

# What is NOT Included
- A guide for converting between JWS serialization formats before and/or after using a pre-existing JWS implementation (see https://github.com/uhhhh2/jwe-jws-serialization-conversion-guide)