### PR TITLE
Clarify questions about account objects.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1265,7 +1265,7 @@ Link: <https://example.com/acme/some-directory>;rel="index"
     "mailto:admin@example.com"
   ],
 
-  "orders": "https://example.com/acme/orders/acct/1"
+  "orders": "https://example.com/acme/acct/1/orders"
 }
 ~~~~~~~~~~
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1183,6 +1183,10 @@ onlyReturnExisting (optional, boolean):
   look up an account URL based on an account key (see
   {{finding-an-account-url-given-a-key}}).
 
+externalAccountBinding (optional, object):
+: An optional field for binding the new account with an existing non-ACME
+  account (see {{ external-account-binding }}).
+
 ~~~~~~~~~~
 POST /acme/new-account HTTP/1.1
 Host: example.com
@@ -1259,7 +1263,9 @@ Link: <https://example.com/acme/some-directory>;rel="index"
   "contact": [
     "mailto:cert-admin@example.com",
     "mailto:admin@example.com"
-  ]
+  ],
+
+  "orders": "https://example.com/acme/orders/acct/1"
 }
 ~~~~~~~~~~
 
@@ -2615,7 +2621,7 @@ Initial contents: The fields and descriptions defined in {{account-objects}}.
 | contact                  | array of string | true         | RFC XXXX  |
 | externalAccountBinding   | object          | true         | RFC XXXX  |
 | termsOfServiceAgreed     | boolean         | true         | RFC XXXX  |
-| orders                   | array of string | false        | RFC XXXX  |
+| orders                   | string          | false        | RFC XXXX  |
 
 \[\[ RFC EDITOR: Please replace XXXX above with the RFC number assigned to this
 document ]]


### PR DESCRIPTION
1) Include optional `externalAccountBinding` field in the Account
   Creation section with a forward pointer to the external account
   binding section.
2) Include the mandatory "orders" field in the example new account
   response.
3) Correct the "orders" field type in Section 9.7.1 to match the type
   from 7.1.2

Thanks to @nzatnsr for flagging these issues on the WG Mailing List.