### PR TITLE
Fix finalization order state in Section 7.4

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1700,7 +1700,7 @@ of the requested subject name, or in an extensionRequest attribute {{!RFC2985}}
 requesting a subjectAltName extension.
 
 A request to finalize an order will result in error if the order indicated does
-not have status "pending", if the CSR and order identifiers differ, or if the
+not have status "ready", if the CSR and order identifiers differ, or if the
 account is not authorized for the identifiers indicated in the CSR.
 
 A valid request to finalize an order will return the order to be finalized.


### PR DESCRIPTION
When the "ready" status was added to the order process we missed a place
in Section 7.4 where the specification claims an order should be in
status "processing" when it is ready for finalization. This commit
changes this sentence to say the order is ready for finalization when it
is status "ready".

Thanks to @nzatnsr for flagging this issue on-list.
