### PR TITLE
Clients SHOULD NOT assume ident/authz/chal sort order.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -869,7 +869,7 @@ This field is structured as a problem document {{!RFC7807}}.
 authorizations (required, array of string):
 : For pending orders, the authorizations that the client needs to complete
 before the requested certificate can be issued (see
-{{identifier-authorization}}).  For final orders (in the "valid" or "invalid" state), the authorizations that
+{{identifier-authorization}}). The authorizations required are dictated by server policy and there may not be a 1:1 relationshop between the order identifiers and the authorizations required. For final orders (in the "valid" or "invalid" state), the authorizations that
 were completed.  Each entry is a URL from which an authorization can be fetched
 with a GET request.
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -961,7 +961,9 @@ challenges that were used.  Each array entry is an object with parameters
 required to validate the challenge.  A client should attempt to fulfill
 one of these challenges, and a server should consider any one of the challenges
 sufficient to make the authorization valid.  For final authorizations, it contains
-the challenges that were successfully completed.
+the challenges that were successfully completed. Clients SHOULD NOT make any
+assumptions about the sort order of "challenges" elements returned from the
+server.
 
 wildcard (optional, boolean):
 : For authorizations created as a result of a newOrder request containing a DNS
@@ -1663,7 +1665,9 @@ requested certificate.  In the order object, any authorization referenced in the
 transaction that the client must complete before the server will issue the
 certificate (see {{identifier-authorization}}).  If the client fails to complete
 the required actions before the "expires" time, then the server SHOULD change
-the status of the order to "invalid" and MAY delete the order resource.
+the status of the order to "invalid" and MAY delete the order resource. Clients
+SHOULD NOT make any assumptions about the sort order of "identifiers" or
+"authorizations" elements in the returned order object.
 
 Once the client believes it has fulfilled the server's requirements, it should
 send a POST request to the order resource's finalize URL. The POST body MUST

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -869,7 +869,7 @@ This field is structured as a problem document {{!RFC7807}}.
 authorizations (required, array of string):
 : For pending orders, the authorizations that the client needs to complete
 before the requested certificate can be issued (see
-{{identifier-authorization}}). The authorizations required are dictated by server policy and there may not be a 1:1 relationshop between the order identifiers and the authorizations required. For final orders (in the "valid" or "invalid" state), the authorizations that
+{{identifier-authorization}}). The authorizations required are dictated by server policy and there may not be a 1:1 relationship between the order identifiers and the authorizations required. For final orders (in the "valid" or "invalid" state), the authorizations that
 were completed.  Each entry is a URL from which an authorization can be fetched
 with a GET request.
 


### PR DESCRIPTION
This PR clarifies that a client SHOULD NOT assume that the "identifiers", "authorizations" or "challenges" arrays returned in various server response objects are sorted.

This PR also clarifies that while some [popular ACME server implementations](https://github.com/letsencrypt/boulder) have a 1:1 relationship between order identifiers and order authorizations this isn't a universal truth.

This resolves https://github.com/ietf-wg-acme/acme/issues/419