### PR TITLE
7.1.4 - Authz Objects - Remove dupe sentence.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -960,8 +960,7 @@ order to prove possession of the identifier.  For final authorizations (in the "
 challenges that were used.  Each array entry is an object with parameters
 required to validate the challenge.  A client should attempt to fulfill
 one of these challenges, and a server should consider any one of the challenges
-sufficient to make the authorization valid.  For final authorizations, it contains
-the challenges that were successfully completed.
+sufficient to make the authorization valid.
 
 wildcard (optional, boolean):
 : For authorizations created as a result of a newOrder request containing a DNS


### PR DESCRIPTION
In section 7.1.4 "Authorization Objects" the "challenges" field is described as containing:
> For final authorizations (in the "valid" or "invalid" state), the challenges that were used.

Later, after discussing the array entries a duplicate sentence appears: 
> For final authorizations, it contains the challenges that were successfully completed.

This is already covered by the initial description of what a final authorization's challenges array holds and so this commit removes the second redundant sentence.