### PR TITLE
Section 9.7: Add missing new registry entry

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2588,11 +2588,12 @@ This document requests that IANA create the following new registries:
 
 1. ACME Account Object Fields ({{iana-account}})
 2. ACME Order Object Fields ({{iana-order}})
-3. ACME Error Types ({{iana-error}})
-4. ACME Resource Types ({{iana-resource}})
-5. ACME Directory Metadata Fields ({{iana-meta}})
-6. ACME Identifier Types ({{iana-identifier}})
-7. ACME Validation Methods ({{iana-validation}})
+3. ACME Authorization Object Fields ({{iana-authz}})
+4. ACME Error Types ({{iana-error}})
+5. ACME Resource Types ({{iana-resource}})
+6. ACME Directory Metadata Fields ({{iana-meta}})
+7. ACME Identifier Types ({{iana-identifier}})
+8. ACME Validation Methods ({{iana-validation}})
 
 All of these registries are under a heading of "Automated Certificate Management
 Environment (ACME) Protocol" and are administered under a Specification


### PR DESCRIPTION
Section 9.7 "New Registries" itemizes the subsections that include new IANA registries. We added a subsection for "Authorization Object Fields" but forgot to add a link to it from the top level 9.7 text. This commit adds that forward pointer.