### PR TITLE
Section 6.2: add missing "," after "e.g.".

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -355,7 +355,7 @@ JWS objects sent in ACME requests MUST meet the following additional criteria:
 * The JWS Protected Header MUST include the following fields:
   * "alg" (Algorithm)
   * "jwk" (JSON Web Key, for all requests not signed using an existing
-          account, e.g. newAccount)
+          account, e.g., newAccount)
   * "kid" (Key ID, for all requests signed using an existing account)
   * "nonce" (defined in {{replay-protection}} below)
   * "url" (defined in {{request-url-integrity}} below)


### PR DESCRIPTION
Thanks to @FGasper [for reporting](https://mailarchive.ietf.org/arch/msg/acme/iY0vxQVo1LQW_koDfvKtHUollQk).