### PR TITLE
Remove exception for certificate GET.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -463,17 +463,6 @@ resources (see {{resources}}), in addition to POST-as-GET requests
 for these resources.  This enables clients to bootstrap into the
 ACME authentication system.
 
-The server MAY allow GET requests for certificate resources in
-order to allow certificates to be fetched by a lower-privileged
-process, e.g., the web server that will use the referenced
-certificate chain.  (See {{?I-D.ietf-acme-star}} for more advanced
-cases.)  A server that allows GET requests for certificate resources
-can still provide a degree of access control by assigning them
-capability URLs {{?W3C.WD-capability-urls-20140218}}.
-As above, if the server does not allow GET requests for a given
-resource, it MUST return an error with status code 405 "Method Not
-Allowed" and type "malformed".
-
 ## Request URL Integrity
 
 It is common in deployment for the entity terminating TLS for HTTPS to be different


### PR DESCRIPTION
This exception doesn't actually improve interop for STAR clients, and it introduces complexity into the security analysis of ACME. STAR can easily solve the problem by defining a new field on orders that provides an explicitly GETtable URL, with whatever security properties the STAR project needs.