### PR TITLE
Fix cross-reference in IANA considerations

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2964,7 +2964,7 @@ Template:
   string
 * Reference: Where this field is defined
 
-Initial contents: The fields and descriptions defined in {{account-objects}}.
+Initial contents: The fields and descriptions defined in {{directory}}.
 
 | Field Name              | Field Type      | Reference |
 |:------------------------|:----------------|:----------|


### PR DESCRIPTION
The definition for "meta" fields accidentally pointed to the section on account objects.