### PR TITLE
Add a meta flag to indicate when GET requests for certificates are allowed

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -840,6 +840,10 @@ externalAccountRequired (optional, boolean):
 new-account requests include an "externalAccountBinding" field associating the
 new account with an external account.
 
+certificateGET (optional, boolean):
+: If this field is present and set to "true", then the CA allows GET
+requests to certificate URLs (see {{post-as-get}}).
+
 Clients access the directory by sending a GET request to the directory URL.
 
 ~~~~~~~~~~

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -841,7 +841,7 @@ new-account requests include an "externalAccountBinding" field associating the
 new account with an external account.
 
 certificateGET (optional, boolean):
-: If this field is present and set to "true", then the CA allows GET
+: If this field is present and set to "true", then the server allows GET
 requests to certificate URLs (see {{post-as-get}}).
 
 Clients access the directory by sending a GET request to the directory URL.


### PR DESCRIPTION
This avoids the need for the client to guess.  Assumes that #459 will not be merged.