### PR TITLE
Fix example URL

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2535,7 +2535,7 @@ A client responds with an empty object ({}) to acknowledge that the challenge
 can be validated by the server.
 
 ~~~~~~~~~~
-POST /acme/authz/PAniVnsZcis/0
+POST /acme/chall/prV_B7yEyA4
 Host: example.com
 Content-Type: application/jose+json
 


### PR DESCRIPTION
This URL should point to `/acme/chall/prV_B7yEyA4` instead of `/acme/authz/PAniVnsZcis/0`. I have written a mail with details regarding this change to the working groups mailing list, which is currently waiting for approval through a list moderator.