### PR TITLE
Fix some nits for AUTH48.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1868,7 +1868,7 @@ client to submit a new finalize request with an amended CSR.
 
 A request to finalize an order will result in error if the order is not in the
 "ready" state.  In such cases, the server MUST return a 403 (Forbidden) error
-with a problem document of type "badOrderState".  The client should then send a
+with a problem document of type "orderNotReady".  The client should then send a
 POST-as-GET request to the order resource to obtain its current state.  The
 status of the order will indicate what action the client should take (see
 below).

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1100,7 +1100,7 @@ wildcard (optional, boolean):
 : This field MUST be present and true for authorizations created as
 a result of a newOrder request containing a DNS identifier with a
 value that was a wildcard domain name.  For other authorizations,
-it MUST be absent.  Wildcard domain names are described in Section 7.1.2.
+it MUST be absent.  Wildcard domain names are described in {{order-objects}}.
 
 The only type of identifier defined by this specification is a fully qualified
 domain name (type: "dns"). The domain name MUST be encoded in the


### PR DESCRIPTION
- badState should be orderNotReady
- Use "wildcard domain name" consistently instead of "wildcard prefix"