### PR TITLE
Include the 'index' link relation in all example server responses that return a resource

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -932,6 +932,7 @@ relation indicating where further entries can be acquired.
 ~~~~~~~~~~
 HTTP/1.1 200 OK
 Content-Type: application/json
+Link: <https://example.com/acme/some-directory>;rel="index"
 Link: <https://example.com/acme/orders/rzGoeA?cursor=2>;rel="next"
 
 {
@@ -1782,6 +1783,7 @@ certificate will be issued.
 ~~~~~~~~~~
 HTTP/1.1 201 Created
 Replay-Nonce: MYAuvOpaoIiywTezizk5vw
+Link: <https://example.com/acme/some-directory>;rel="index"
 Location: https://example.com/acme/order/TOlocE8rfgo
 
 {
@@ -1898,6 +1900,7 @@ action the client should take:
 ~~~~~~~~~~
 HTTP/1.1 200 OK
 Replay-Nonce: CGf81JWBsq8QyIgPCi9Q9X
+Link: <https://example.com/acme/some-directory>;rel="index"
 Location: https://example.com/acme/order/TOlocE8rfgo
 
 {
@@ -2222,6 +2225,7 @@ Content-Type: application/jose+json
 
 HTTP/1.1 200 OK
 Content-Type: application/json
+Link: <https://example.com/acme/some-directory>;rel="index"
 
 {
   "status": "valid",
@@ -2367,6 +2371,7 @@ has already been revoked, the server returns an error response with status code 
 HTTP/1.1 200 OK
 Replay-Nonce: IXVHDyxIRGcTE0VSblhPzw
 Content-Length: 0
+Link: <https://example.com/acme/some-directory>;rel="index"
 
 --- or ---
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -672,6 +672,7 @@ containing only the eight identifiers not listed in the problem document.
 ~~~~~
 HTTP/1.1 403 Forbidden
 Content-Type: application/problem+json
+Link: <https://example.com/acme/some-directory>;rel="index"
 
 {
     "type": "urn:ietf:params:acme:error:malformed",
@@ -1300,6 +1301,7 @@ Host: example.com
 HTTP/1.1 200 OK
 Replay-Nonce: oFvnlFP1wIhRlYS2jTaXbA
 Cache-Control: no-store
+Link: <https://example.com/acme/some-directory>;rel="index"
 ~~~~~~~~~~
 
 Proxy caching of responses from the newNonce resource can cause
@@ -1481,6 +1483,7 @@ order for instructions on how to agree to the terms.
 ~~~~~
 HTTP/1.1 403 Forbidden
 Replay-Nonce: T81bdZroZ2ITWSondpTmAw
+Link: <https://example.com/acme/some-directory>;rel="index"
 Link: <https://example.com/acme/terms/2017-6-02>;rel="terms-of-service"
 Content-Type: application/problem+json
 Content-Language: en
@@ -2379,6 +2382,7 @@ HTTP/1.1 403 Forbidden
 Replay-Nonce: IXVHDyxIRGcTE0VSblhPzw
 Content-Type: application/problem+json
 Content-Language: en
+Link: <https://example.com/acme/some-directory>;rel="index"
 
 {
   "type": "urn:ietf:params:acme:error:unauthorized",

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1400,8 +1400,8 @@ requests for management actions on this account, as described below.
 HTTP/1.1 201 Created
 Content-Type: application/json
 Replay-Nonce: D8s4D2mLs8Vn-goWuPQeKA
-Location: https://example.com/acme/acct/evOfKhNU60wg
 Link: <https://example.com/acme/some-directory>;rel="index"
+Location: https://example.com/acme/acct/evOfKhNU60wg
 
 {
   "status": "valid",


### PR DESCRIPTION
Section 7.1 says:
```The "index" link relation is present on all resources other than the directory and indicates the URL of the directory.```

This PR adds an example "index" link relation to the example server responses that return a resource but that didn't already have it.

I'm interpreting "is present on all resources" to _not_ include responses that return a problem document.  Is that right?