### PR TITLE
Some more edits from thorough review on paper.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1534,7 +1534,7 @@ Content-Type: application/jose+json
     "url": "https://example.com/acme/new-account"
   }),
   "payload": base64url({
-    "contact": ["mailto:cert-admin@example.com"],
+    "contact": ["mailto:example@anonymous.invalid"],
     "termsOfServiceAgreed": true,
 
     "externalAccountBinding": {

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -399,7 +399,7 @@ private key unless otherwise specified.  The server MUST verify the JWS before
 processing the request. Encapsulating request bodies in JWS provides
 authentication of requests.
 
-JWS objects sent as the body of an ACME request MUST meet the following additional criteria:
+A JWS object sent as the body of an ACME request MUST meet the following additional criteria:
 
 * The JWS MUST be in the  Flattened JSON Serialization {{!RFC7515}}
 * The JWS MUST NOT have multiple signatures
@@ -1139,7 +1139,7 @@ name validation.
     }
   ],
 
-  "wildcard": true
+  "wildcard": false
 }
 ~~~~~~~~~~
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1886,16 +1886,20 @@ action the client should take:
 * "invalid": The certificate will not be issued.  Consider this order process
   abandoned.
 
+* "pending": The server does not believe that the client has fulfilled the
+  requirements.  Check the "authorizations" array for entries that are still
+  pending.
+
+* "ready": The server agrees that the requirements have been
+  fulfilled, and is awaiting finalization.  Submit a finalization
+  request.
+
 * "processing": The certificate is being issued. Send a POST-as-GET request after the
   time given in the Retry-After header field of the response, if
   any.
 
 * "valid": The server has issued the certificate and provisioned its URL to the
   "certificate" field of the order.  Download the certificate.
-
-* "pending": This status should not be returned after a successful finalize request.
-
-* "ready": This status should not be returned after a successful finalize request.
 
 ~~~~~~~~~~
 HTTP/1.1 200 OK

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2177,7 +2177,12 @@ Content-Type: application/jose+json
 }
 ~~~~~~~~~~
 
-The server provides a 200 (OK) response with the challenge object as its body.
+The server MUST
+ignore any fields in the response object that are not specified as response
+fields for this type of challenge.  Note that the challenges in this document do
+not define any response fields, but future specifications might define them.
+The server provides a 200 (OK) response
+with the updated challenge object as its body.
 
 If the client's response is invalid for any reason or does not provide the
 server with appropriate information to validate the challenge, then the server

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -399,7 +399,7 @@ private key unless otherwise specified.  The server MUST verify the JWS before
 processing the request. Encapsulating request bodies in JWS provides
 authentication of requests.
 
-JWS objects sent as the body of ACME requests MUST meet the following additional criteria:
+JWS objects sent as the body of an ACME request MUST meet the following additional criteria:
 
 * The JWS MUST be in the  Flattened JSON Serialization {{!RFC7515}}
 * The JWS MUST NOT have multiple signatures
@@ -2177,9 +2177,11 @@ Content-Type: application/jose+json
 }
 ~~~~~~~~~~
 
-The server MUST
+The server updates the authorization document by updating its representation of
+the challenge with the response object provided by the client.  The server MUST
 ignore any fields in the response object that are not specified as response
-fields for this type of challenge.  Note that the challenges in this document do
+fields for this type of challenge.
+Note that the challenges in this document do
 not define any response fields, but future specifications might define them.
 The server provides a 200 (OK) response
 with the updated challenge object as its body.
@@ -2193,11 +2195,10 @@ that have been provisioned to a web server.
 The server is said to "finalize" the authorization when it has completed
 one of the validations.  This is done by assigning the authorization a status of "valid"
 or "invalid", corresponding to whether it considers the account authorized
-for the identifier. If the final state is "valid", then the server MUST set
-an "expires" field, and MAY update the "expires" field if one was already present.
-When finalizing an authorization, the server MAY remove
-challenges other than the one that was completed.
-The server SHOULD NOT remove challenges with status "invalid".
+for the identifier. If the final state is "valid", then the server MUST include
+an "expires" field. When finalizing an authorization, the server MAY remove
+challenges other than the one that was completed, and it may modify the "expires"
+field. The server SHOULD NOT remove challenges with status "invalid".
 
 Usually, the validation process will take some time, so the client will need to
 poll the authorization resource to see when it is finalized.  For challenges


### PR DESCRIPTION
- Some grammar fixes
- POST-as-GETs should be indicated as having a signature in flow
- Specify that the JWS profile we define in Section 6.2 is for ACME request bodies, to
  distinuish it from the profile used for External Account Binding. They
  have incompatible requirements: MUST NOT use MAC vs MUST use MAC.
- Clarify that Replay-Nonce is an HTTP header field since it's defined
  near JWS header parameters.
- Don't include "wildcard": false in examples. Section 7.1.4 requires
  that it MUST be absent when false.
- There was lingering language in the Section 7.5.1 about "updating"
  an authorization body in response to fields in a challenge POST.
  Since the challenge POST is now described explicitly as "an empty
  JSON body", this language didn't make sense. Fixed.