### PR TITLE
Fix formatting in IANA section.

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -2753,10 +2753,10 @@ Applications that use this media type: ACME clients and servers, HTTP servers, o
 
 Additional information:
 
-  Deprecated alias names for this type: n/a
-  Magic number(s): n/a
-  File extension(s): .pem
-  Macintosh file type code(s): n/a
+    Deprecated alias names for this type: n/a
+    Magic number(s): n/a
+    File extension(s): .pem
+    Macintosh file type code(s): n/a
 
 Person & email address to contact for further information: See Authors' Addresses section.
 
@@ -2870,7 +2870,6 @@ Initial contents: The fields and descriptions defined in {{account-objects}}.
 
 | Field Name               | Field Type      | Requests     | Reference |
 |:-------------------------|:----------------|:-------------|:----------|
-=======
 | status                   | string          | new, account | RFC 8555  |
 | contact                  | array of string | new, account | RFC 8555  |
 | externalAccountBinding   | object          | new          | RFC 8555  |
@@ -2889,7 +2888,7 @@ Template:
 * Field name: The string to be used as a field name in the JSON object
 * Field type: The type of value to be provided, e.g., string, boolean, array of
   string
-* Client configurable: Boolean indicating whether the server should accept
+* Configurable: Boolean indicating whether the server should accept
   values provided by the client
 * Reference: Where this field is defined
 
@@ -2918,7 +2917,7 @@ Template:
 * Field name: The string to be used as a field name in the JSON object
 * Field type: The type of value to be provided, e.g., string, boolean, array of
   string
-* Client configurable: Boolean indicating whether the server should accept
+* Configurable: Boolean indicating whether the server should accept
   values provided by the client
 * Reference: Where this field is defined
 


### PR DESCRIPTION
For pem-certificate-chain, the "Addition information" section was
getting jumbled all onto one line by the Markdown to HTML generator.

The table for Fields in Account Objects was jumbled.

In the template for some registries, a field was called "Client
configurable" in the next but "Configurable" in the table. Changed to
always say "Configurable."