### PR TITLE
Normalize examples

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1022,7 +1022,7 @@ certificate (optional, string):
 
   "finalize": "https://example.com/acme/order/TOlocE8rfgo/finalize",
 
-  "certificate": "https://example.com/acme/cert/jWCdfHVGY2M"
+  "certificate": "https://example.com/acme/cert/mAt3xBGaobw"
 }
 ~~~~~~~~~~
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1005,7 +1005,7 @@ certificate (optional, string):
 ~~~~~~~~~~
 {
   "status": "valid",
-  "expires": "2015-03-01T14:09:07.99Z",
+  "expires": "2016-01-20T14:09:07.99Z",
 
   "identifiers": [
     { "type": "dns", "value": "www.example.org" }
@@ -1791,17 +1791,19 @@ Location: https://example.com/acme/order/TOlocE8rfgo
 
 {
   "status": "pending",
-  "expires": "2016-01-01T00:00:00Z",
+  "expires": "2016-01-05T14:09:07.99Z",
 
   "notBefore": "2016-01-01T00:00:00Z",
   "notAfter": "2016-01-08T00:00:00Z",
 
   "identifiers": [
     { "type": "dns", "value": "www.example.org" },
+    { "type": "dns", "value": "example.org" },
   ],
 
   "authorizations": [
     "https://example.com/acme/authz/PAniVnsZcis",
+    "https://example.com/acme/authz/r4HqLzrSrpI"
   ],
 
   "finalize": "https://example.com/acme/order/TOlocE8rfgo/finalize"
@@ -1908,10 +1910,10 @@ Location: https://example.com/acme/order/TOlocE8rfgo
 
 {
   "status": "valid",
-  "expires": "2015-12-31T00:17:00.00-09:00",
+  "expires": "2016-01-20T14:09:07.99Z",
 
-  "notBefore": "2015-12-31T00:17:00.00-09:00",
-  "notAfter": "2015-12-31T00:17:00.00-09:00",
+  "notBefore": "2016-01-01T00:00:00Z",
+  "notAfter": "2016-01-08T00:00:00Z",
 
   "identifiers": [
     { "type": "dns", "value": "www.example.org" }
@@ -2123,7 +2125,7 @@ Link: <https://example.com/acme/some-directory>;rel="index"
 
 {
   "status": "pending",
-  "expires": "2018-03-03T14:09:30Z",
+  "expires": "2016-01-02T14:09:30Z",
 
   "identifier": {
     "type": "dns",
@@ -2379,7 +2381,7 @@ Link: <https://example.com/acme/some-directory>;rel="index"
 --- or ---
 
 HTTP/1.1 403 Forbidden
-Replay-Nonce: IXVHDyxIRGcTE0VSblhPzw
+Replay-Nonce: lXfyFzi6238tfPQRwgfmPU
 Content-Type: application/problem+json
 Content-Language: en
 Link: <https://example.com/acme/some-directory>;rel="index"

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -912,8 +912,8 @@ a POST-as-GET request, as described in {{orders-list}}.
 {
   "status": "valid",
   "contact": [
-    "mailto:cert-admin@example.com",
-    "mailto:admin@example.com"
+    "mailto:cert-admin@example.org",
+    "mailto:admin@example.org"
   ],
   "termsOfServiceAgreed": true,
   "orders": "https://example.com/acme/orders/rzGoeA"
@@ -1533,7 +1533,10 @@ Content-Type: application/jose+json
     "url": "https://example.com/acme/new-account"
   }),
   "payload": base64url({
-    "contact": ["mailto:cert-admin@example.org"],
+    "contact": [
+      "mailto:cert-admin@example.org",
+      "mailto:admin@example.org"
+    ],
     "termsOfServiceAgreed": true,
 
     "externalAccountBinding": {

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1008,7 +1008,7 @@ certificate (optional, string):
   "expires": "2016-01-20T14:09:07.99Z",
 
   "identifiers": [
-    { "type": "dns", "value": "www.example.org" }
+    { "type": "dns", "value": "www.example.org" },
     { "type": "dns", "value": "example.org" },
   ],
 

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -680,10 +680,10 @@ Link: <https://example.com/acme/some-directory>;rel="index"
     "subproblems": [
         {
             "type": "urn:ietf:params:acme:error:malformed",
-            "detail": "Invalid underscore in DNS name \"_example.com\"",
+            "detail": "Invalid underscore in DNS name \"_example.org\"",
             "identifier": {
                 "type": "dns",
-                "value": "_example.com"
+                "value": "_example.org"
             }
         },
         {
@@ -1008,8 +1008,8 @@ certificate (optional, string):
   "expires": "2015-03-01T14:09:07.99Z",
 
   "identifiers": [
-    { "type": "dns", "value": "example.com" },
-    { "type": "dns", "value": "www.example.com" }
+    { "type": "dns", "value": "www.example.org" }
+    { "type": "dns", "value": "example.org" },
   ],
 
   "notBefore": "2016-01-01T00:00:00Z",
@@ -1125,7 +1125,7 @@ name validation.
 
   "identifier": {
     "type": "dns",
-    "value": "example.org"
+    "value": "www.example.org"
   },
 
   "challenges": [
@@ -1350,8 +1350,8 @@ Content-Type: application/jose+json
   "payload": base64url({
     "termsOfServiceAgreed": true,
     "contact": [
-      "mailto:cert-admin@example.com",
-      "mailto:admin@example.com"
+      "mailto:cert-admin@example.org",
+      "mailto:admin@example.org"
     ]
   }),
   "signature": "RZPOnYoPs1PhjszF...-nh6X1qtOFPB519I"
@@ -1407,8 +1407,8 @@ Location: https://example.com/acme/acct/evOfKhNU60wg
   "status": "valid",
 
   "contact": [
-    "mailto:cert-admin@example.com",
-    "mailto:admin@example.com"
+    "mailto:cert-admin@example.org",
+    "mailto:admin@example.org"
   ],
 
   "orders": "https://example.com/acme/acct/evOfKhNU60wg/orders"
@@ -1455,8 +1455,8 @@ Content-Type: application/jose+json
   }),
   "payload": base64url({
     "contact": [
-      "mailto:certificates@example.com",
-      "mailto:admin@example.com"
+      "mailto:certificates@example.org",
+      "mailto:admin@example.org"
     ]
   }),
   "signature": "hDXzvcj8T6fbFbmn...rDzXzzvzpRy64N0o"
@@ -1533,7 +1533,7 @@ Content-Type: application/jose+json
     "url": "https://example.com/acme/new-account"
   }),
   "payload": base64url({
-    "contact": ["mailto:example@anonymous.invalid"],
+    "contact": ["mailto:cert-admin@example.org"],
     "termsOfServiceAgreed": true,
 
     "externalAccountBinding": {
@@ -1764,7 +1764,7 @@ Content-Type: application/jose+json
   }),
   "payload": base64url({
     "identifiers": [
-      { "type": "dns", "value": "example.com" }
+      { "type": "dns", "value": "www.example.org" }
     ],
     "notBefore": "2016-01-01T00:04:00+04:00",
     "notAfter": "2016-01-08T00:04:00+04:00"
@@ -1797,7 +1797,7 @@ Location: https://example.com/acme/order/TOlocE8rfgo
   "notAfter": "2016-01-08T00:00:00Z",
 
   "identifiers": [
-    { "type": "dns", "value": "example.com" },
+    { "type": "dns", "value": "www.example.org" },
   ],
 
   "authorizations": [
@@ -1914,8 +1914,8 @@ Location: https://example.com/acme/order/TOlocE8rfgo
   "notAfter": "2015-12-31T00:17:00.00-09:00",
 
   "identifiers": [
-    { "type": "dns", "value": "example.com" },
-    { "type": "dns", "value": "www.example.com" }
+    { "type": "dns", "value": "www.example.org" }
+    { "type": "dns", "value": "example.org" },
   ],
 
   "authorizations": [
@@ -1978,7 +1978,7 @@ Content-Type: application/jose+json
   "payload": base64url({
     "identifier": {
       "type": "dns",
-      "value": "example.net"
+      "value": "example.org"
     }
   }),
   "signature": "nuSDISbWG8mMgE7H...QyVUL68yzf3Zawps"
@@ -2127,7 +2127,7 @@ Link: <https://example.com/acme/some-directory>;rel="index"
 
   "identifier": {
     "type": "dns",
-    "value": "example.org"
+    "value": "www.example.org"
   },
 
   "challenges": [
@@ -2236,7 +2236,7 @@ Link: <https://example.com/acme/some-directory>;rel="index"
 
   "identifier": {
     "type": "dns",
-    "value": "example.org"
+    "value": "www.example.org"
   },
 
   "challenges": [
@@ -2386,7 +2386,7 @@ Link: <https://example.com/acme/some-directory>;rel="index"
 
 {
   "type": "urn:ietf:params:acme:error:unauthorized",
-  "detail": "No authorization provided for name example.net"
+  "detail": "No authorization provided for name example.org"
 }
 ~~~~~~~~~~
 
@@ -2665,11 +2665,11 @@ The record provisioned to the DNS contains the base64url encoding of this digest
 client constructs the validation domain name by prepending the label
 "\_acme-challenge" to the domain name being validated, then provisions a TXT
 record with the digest value under that name. For example, if the domain name
-being validated is "example.org", then the client would provision the following
+being validated is "www.example.org", then the client would provision the following
 DNS record:
 
 ~~~~~~~~~~
-_acme-challenge.example.org. 300 IN TXT "gfj9Xq...Rg85nM"
+_acme-challenge.www.example.org. 300 IN TXT "gfj9Xq...Rg85nM"
 ~~~~~~~~~~
 
 A client responds with an empty object ({}) to acknowledge that the challenge

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1009,7 +1009,7 @@ certificate (optional, string):
 
   "identifiers": [
     { "type": "dns", "value": "www.example.org" },
-    { "type": "dns", "value": "example.org" },
+    { "type": "dns", "value": "example.org" }
   ],
 
   "notBefore": "2016-01-01T00:00:00Z",

--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1801,7 +1801,7 @@ Location: https://example.com/acme/order/TOlocE8rfgo
 
   "identifiers": [
     { "type": "dns", "value": "www.example.org" },
-    { "type": "dns", "value": "example.org" },
+    { "type": "dns", "value": "example.org" }
   ],
 
   "authorizations": [
@@ -1919,8 +1919,8 @@ Location: https://example.com/acme/order/TOlocE8rfgo
   "notAfter": "2016-01-08T00:00:00Z",
 
   "identifiers": [
-    { "type": "dns", "value": "www.example.org" }
-    { "type": "dns", "value": "example.org" },
+    { "type": "dns", "value": "www.example.org" },
+    { "type": "dns", "value": "example.org" }
   ],
 
   "authorizations": [


### PR DESCRIPTION
Since `example.com` is consistently used to represent the ACME server, we should always use `www.example.org` to represent the ACME client. Whenever there's a single hostname we prefer the `www` variant because the prefix makes it easier to quickly distinguish from `example.com`. When there are two hostnames we use both `www.example.org` and `example.org`.

Since we already used one order ID consistently through the doc, I made sure that its identifiers, notBefore, and notAfter were always the same. I tweaked the "expires" so it would be in a reasonable range (not precisely equal to the notBefore). Note that the "pending" version of the order has a slightly different expires than the "valid" order.

One version of the finalized order had a cert ID of jWCdfHVGY2M and another had mAt3xBGaobw. Harmonized on mAt3xBGaobw since it was also used in the certificate retrieval example.

Also fixed an accidentally duplicated nonce.