### PR TITLE
Use a consistent set of identifiers for the "Applying for Certificate Issuance" section examples

### DIFF
--- a/draft-ietf-acme-acme.md
+++ b/draft-ietf-acme-acme.md
@@ -1768,7 +1768,8 @@ Content-Type: application/jose+json
   }),
   "payload": base64url({
     "identifiers": [
-      { "type": "dns", "value": "www.example.org" }
+      { "type": "dns", "value": "www.example.org" },
+      { "type": "dns", "value": "example.org" }
     ],
     "notBefore": "2016-01-01T00:04:00+04:00",
     "notAfter": "2016-01-08T00:04:00+04:00"


### PR DESCRIPTION
The "Applying for Certificate Issuance section" examples should follow a single request through the process. This PR makes the set of identifiers in the initial request match the examples that follow.